### PR TITLE
Bump hl7.fhir.uv.extensions.r5 to 5.3.0

### DIFF
--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -27,7 +27,7 @@ dependencies:
     uri: http://fhir.org/packages/fhir.dicom/ImplementationGuide/fhir.dicom
     version: 2025.2.20250411
   # https://chat.fhir.org/#narrow/channel/215610-shorthand/topic/R5.20Questionnaires.20inheriting.20structuredefinition-implements
-  hl7.fhir.uv.extensions.r5: 5.3.0-ballot-tc1
+  hl7.fhir.uv.extensions.r5: 5.3.0
 
 
 


### PR DESCRIPTION
## Summary

- Bumps `hl7.fhir.uv.extensions.r5` from `5.3.0-ballot-tc1` to the final `5.3.0` published in the HL7 FHIR package registry.
- Without this bump the IG Publisher emits `IG_DEPENDENCY_VERSION_WARNING_OLD` on `ImplementationGuide.dependsOn[2]`, which fails the `Check QA report` gate (`MAX_ALLOWED_WARNINGS=0`). Surfaced when PR #141 hit the QA gate; the warning is unrelated to that change and will block every subsequent build until the dependency is bumped.

## Test plan

- [x] Local IG Publisher build with `5.3.0`: `output/qa.json` reports `errs: 0`, `warnings: 0` (down from 2 / 1).
- [ ] CI: `sushi` and `ig-publisher` jobs green; `Check QA report` passes.