### PR TITLE
Fix dead changelog links to removed uz-core-clinical-condition

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -118,7 +118,7 @@ Added Karakalpak language (kaa) support in the MultilingualName ruleset, used fo
 
 Updated IP holder to Ministry of Health.
 
-[UZ Core Clinical Condition](StructureDefinition-uz-core-clinical-condition.html) added to differentiate clinical (ICD-10) and non-ICD-10 based conditions.
+UZ Core Clinical Condition added to differentiate clinical (ICD-10) and non-ICD-10 based conditions.
 
 Patient disability status has been moved from the [Patient](StructureDefinition-uz-core-patient.html) resource (using a FHIR-standard extension) to the [Condition](StructureDefinition-uz-core-condition.html) resource.
 

--- a/input/translations/ru/pagecontent/changelog.md
+++ b/input/translations/ru/pagecontent/changelog.md
@@ -119,7 +119,7 @@
 
 Обновлён владелец интеллектуальной собственности на Министерство здравоохранения.
 
-Добавлен профиль [UZ Core Clinical Condition](StructureDefinition-uz-core-clinical-condition.html) для разграничения клинических состояний, основанных на МКБ-10, и состояний, не основанных на МКБ-10.
+Добавлен профиль UZ Core Clinical Condition для разграничения клинических состояний, основанных на МКБ-10, и состояний, не основанных на МКБ-10.
 
 Статус инвалидности пациента перенесён из ресурса [Patient](StructureDefinition-uz-core-patient.html) (где он реализовывался через стандартное расширение FHIR) в ресурс [Condition](StructureDefinition-uz-core-condition.html).
 

--- a/input/translations/uz/pagecontent/changelog.md
+++ b/input/translations/uz/pagecontent/changelog.md
@@ -104,7 +104,7 @@ MultilingualName qoidalar to'plamida qoraqalpoq tili (kaa) qo'llab-quvvatlashi q
 
 Intellektual mulk egasi Sog'liqni saqlash vazirligiga yangilandi.
 
-[UZ Core Clinical Condition](StructureDefinition-uz-core-clinical-condition.html) klinik (ICD-10) va ICD-10 ga asoslanmagan holatlarni farqlash uchun qo'shildi.
+UZ Core Clinical Condition klinik (ICD-10) va ICD-10 ga asoslanmagan holatlarni farqlash uchun qo'shildi.
 
 Bemor nogironlik holati [Patient](StructureDefinition-uz-core-patient.html) resursidan (FHIR standart kengaytmasidan foydalangan holda) [Condition](StructureDefinition-uz-core-condition.html) resursiga ko'chirildi.
 


### PR DESCRIPTION
## Context

PR #117 introduced the `lint-changelog-links` workflow
(`.github/workflows/lint-changelog-links.yml` +
`scripts/lint-changelog-links.sh`). The linter verifies that every
`StructureDefinition-<id>.html` link in changelog markdown files resolves to a
real `fsh-generated/resources/StructureDefinition-<id>.json` after SUSHI runs.
The workflow triggers on changes under `input/fsh/**`,
`input/pagecontent/changelog.md`,
`input/translations/*/pagecontent/changelog.md`, and the script itself.

## Problem

The linter currently fails on every PR touching `input/fsh/**` because the
changelog still contains dead links to
`StructureDefinition-uz-core-clinical-condition.html`. The
`UZCoreClinicalCondition` profile was previously removed and merged into
`UZCoreCondition` — this is already documented at the top of the "0.5.0"
section in each language with the correct successor link to
`StructureDefinition-uz-core-condition.html`.

But the older historical entry (where the profile was originally announced
as added) still points to the now-removed resource. Three occurrences:

- `input/pagecontent/changelog.md:121`
- `input/translations/ru/pagecontent/changelog.md:122`
- `input/translations/uz/pagecontent/changelog.md:107`

## Change

Strip the dead markdown link in each of the three files, keeping the plain
text "UZ Core Clinical Condition" so the historical entry remains readable.
No other changes.

## Verification

Local run of `bash scripts/lint-changelog-links.sh` against a build of
`fsh-generated/` exits 0 after this change (was: 3 errors before).

## Impact

After merge, PRs touching `input/fsh/**` (including #141) will no longer be
blocked by the `lint-changelog-links` gate on this particular issue.