### PR TITLE
Require loinc-supplement-uz supplement in ObservationCodesVS

### DIFF
--- a/input/fsh/Aliases.fsh
+++ b/input/fsh/Aliases.fsh
@@ -62,6 +62,7 @@ Alias: $issue-severity = http://hl7.org/fhir/issue-severity
 Alias: $location-status = http://hl7.org/fhir/location-status
 Alias: $location-unit = https://dhp.uz/fhir/core/NamingSystem/location-unit
 Alias: $loinc = http://loinc.org
+Alias: $loinc-supplement-uz = https://terminology.dhp.uz/fhir/CodeSystem/loinc-supplement-uz
 Alias: $loinc-vs = http://loinc.org/vs
 Alias: $medical-product-classification = http://www.whocc.no/atc
 Alias: $mfa = https://gov.uz/ru/mfa

--- a/input/fsh/terminology/ObservationCodesVS.fsh
+++ b/input/fsh/terminology/ObservationCodesVS.fsh
@@ -4,6 +4,8 @@ Title: "Observation codes"
 Description: "Codes for observations, allowing use of LOINC, local laboratory codes, and SNOMED CT as appropriate for the context"
 * ^url = "https://terminology.dhp.uz/fhir/core/ValueSet/observation-codes-vs"
 * ^experimental = true
+* ^extension[0].url = $valueset-supplement
+* ^extension[=].valueCanonical = $loinc-supplement-uz
 
 * include codes from system lab-pan-cs
 * include codes from system $loinc


### PR DESCRIPTION
This is for clarity that the valueset is intended to be used with the codesystem supplement that is available in the [fhir.tx.support.r4](https://registry.fhir.org/package/fhir.tx.support.r4) package.