### PR TITLE
Drop tautological targetScopeCanonical from DMEDVaccineCodesCM

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Check QA report
         run: |
           # Configuration
-          MAX_ALLOWED_ERRORS=52
+          MAX_ALLOWED_ERRORS=0
           MAX_ALLOWED_WARNINGS=0
 
           if [ ! -f "output/qa.json" ]; then

--- a/input/fsh/terminology/DMEDVaccineCodesCM.fsh
+++ b/input/fsh/terminology/DMEDVaccineCodesCM.fsh
@@ -12,7 +12,15 @@ Description: "ConceptMap for mapping DMED Vaccine codes to CVX vaccine codes"
 * group[+].source = Canonical(DMEDVaccineCS)
 * sourceScopeCanonical = Canonical(DMEDVaccineVS)
 * group[=].target = $cvx
-* targetScopeCanonical = Canonical(VaccineCodeVS)
+// targetScopeCanonical intentionally omitted: VaccineCodeVS = $cvx + $air-vaccine,
+// and each group's `target` ($cvx here, $air-vaccine below) already restricts
+// target codes to a subset of that ValueSet, so the canonical was a tautological
+// constraint that triggered an IG Publisher bug
+// (CONCEPTMAP_GROUP_TARGET_CODE_INVALID_VS — the internal expander disagrees
+// with tx and rejects codes that ARE in the ValueSet). Reproducer:
+// https://github.com/vadi2/VadimTestIG/tree/conceptmap-target-vs-bug
+// A proper publisher fix is expected upstream; once it lands, re-add the
+// canonical only if it adds a real constraint over `group.target`.
 
 * group[=].element[+].code = #59
 * group[=].element[=].display = "АКДС R"

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -57,33 +57,6 @@ WARNING: ConceptMap/ssv-administrative-territory-to-regions-cm: ConceptMap.group
 # tx.fhir.org doesn't have all UCUM codes - allowed to be ignored, needs to be reported
 Target Code System http://unitsofmeasure.org doesn't have all content (content = not-present), so the target codes cannot be checked
 
-# IG Publisher bug: ConceptMap target-code validation rejects codes that ARE in the
-# target ValueSet. tx.fhir.org $validate-code returns result:true for these codes;
-# the publisher's internal expander disagrees with tx and emits
-# CONCEPTMAP_GROUP_TARGET_CODE_INVALID_VS for every target.
-# Reproducer: https://github.com/vadi2/VadimTestIG/tree/conceptmap-target-vs-bug
-# IG Publisher bug: ConceptMap target-code validation rejects codes that ARE in the target ValueSet. This has been reported and we can ignore it
-The target code '01' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '03' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '05' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '10' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '19' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '35' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '62' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '90' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '94' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '96' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '98' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '108' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '113' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '137' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '189' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '198' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '207' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '208' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '210' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-The target code '212' is not valid in the value set https://terminology.dhp.uz/fhir/core/ValueSet/vaccine-code-vs|%
-
 # IG publisher has troubles validating property URIs - need to report
 The property uri 'http://terminology.hl7.org/CodeSystem/v2-0203' is not known, so the property values can not be validated fully; unless specified elsewhere, codes will be treated as internal references
 The property uri 'urn:iso:std:iso:3166' is not known, so the property values can not be validated fully; unless specified elsewhere, codes will be treated as internal references


### PR DESCRIPTION
Follow-up to the discussion in #141.

## Why

`DMEDVaccineCodesCM` had `* targetScopeCanonical = Canonical(VaccineCodeVS)`,
where `VaccineCodeVS = $cvx + $air-vaccine`. Each group already constrains
its target codes via `group.target` (`$cvx` for group 1, `$air-vaccine` for
group 2) — both proper subsets of `VaccineCodeVS`. The canonical did not
narrow validation beyond what `group.target` already enforces.

It did, however, trip an IG Publisher bug
(`CONCEPTMAP_GROUP_TARGET_CODE_INVALID_VS`) where the publisher's internal
expander disagrees with tx.fhir.org and rejects target codes that ARE in
the target ValueSet. `tx.fhir.org $validate-code` returns `result:true` for
all of them. Reproducer (by @vadi2):
https://github.com/vadi2/VadimTestIG/tree/conceptmap-target-vs-bug

## What still validates after the drop

Confirmed in the reproducer (with the canonical removed and one target
code replaced with `#99999`):

```
ERROR: ConceptMap/...target[0].code:
The target code '99999' is not valid in the code system http://hl7.org/fhir/sid/cvx|20250715
```

The message says "code system", not "value set" — the publisher still
validates target codes against the CodeSystem named in `group.target` via
tx. What's lost is only the VS-membership pass on top, which for this file
was the redundant one.

## Changes

- `input/fsh/terminology/DMEDVaccineCodesCM.fsh` — replace the
  `targetScopeCanonical` line with an explanatory comment block (covering
  the tautology, the publisher bug, the reproducer link, and a note to
  re-add only when it adds a real constraint over `group.target`).
- `input/ignoreWarnings.txt` — remove the 26-line block that suppressed the
  now-impossible `CONCEPTMAP_GROUP_TARGET_CODE_INVALID_VS` errors for
  `vaccine-code-vs`.
- `.github/workflows/validate-docs.yml` — `MAX_ALLOWED_ERRORS=52` → `0`.

## Verification

Local build (`./_genonce.sh`): `errs:0, warnings:0, hints:5046`. No new
errors or warnings introduced; `output/qa.json` is clean.

## Upstream fix

The proper long-term fix is in the IG Publisher itself, and the
reproducer above is ready for that work. This PR is a local workaround
that becomes safe to revert once the publisher bug is resolved (and only
if reintroducing `targetScopeCanonical` would add a real constraint).