### PR TITLE
Align referral workflow to PaymentType extension

### DIFF
--- a/input/images-source/referral-sequence.plantuml
+++ b/input/images-source/referral-sequence.plantuml
@@ -7,10 +7,10 @@ participant "DHP" as DHP
 participant "Approval\ncommissions" as Comm
 participant "Performing\nfacility" as Fac
 
-Clin -> DHP : POST ServiceRequest\n(intent = order, coverageKind)
+Clin -> DHP : POST ServiceRequest\n(intent = order, PaymentType)
 activate DHP
 
-alt coverageKind = state-insurance
+alt PaymentType = State-funded
   DHP -> DHP : create approval Task chain\n(first Task status = requested)
   loop approve-family-doctor ... approve-hospitalization
     Comm -> DHP : advance Task\n(accepted -> in-progress -> completed)

--- a/input/pagecontent/workflow-referral.md
+++ b/input/pagecontent/workflow-referral.md
@@ -4,13 +4,13 @@ This workflow shows how a referral is created and fulfilled. Referrals are where
 
 > Profile status: the ServiceRequest and Task profiles are in development. This page describes the intended modelling so systems can build against it now; until the profiles publish, use the base FHIR R5 resources and the rules below. [Procedure](StructureDefinition-uz-core-procedure.html), [Observation](StructureDefinition-uz-core-observation.html), [Encounter](StructureDefinition-uz-core-encounter.html) and [Condition](StructureDefinition-uz-core-condition.html) used at fulfilment are profiled.
 
-Actors: the referring clinician; approval commissions (for state-insurance referrals); the performing facility.
+Actors: the referring clinician; approval commissions (for state-funded referrals); the performing facility.
 
 <div>{% include referral-sequence.svg %}</div><br clear="all"/>
 
 ### 1. Create the referral
 
-The clinician creates a `ServiceRequest` (`intent = order`) carrying the referral classification: the service requested in `code`, urgency in `priority` (`routine` \| `urgent` \| `stat`), the target service via `HealthcareService`, the clinical justification in `reason`, and the financing type in a `coverageKind` extension (`state-insurance` \| `insurance` \| `self-payment` \| `other`).
+The clinician creates a `ServiceRequest` (`intent = order`) carrying the referral classification: the service requested in `code`, urgency in `priority` (`routine` \| `urgent` \| `stat`), the target service via `HealthcareService`, the clinical justification in `reason`, and the financing type in the [PaymentType](StructureDefinition-payment-type.html) extension (`Free` \| `Paid` \| `Insurance` \| `State-funded`).
 
 ```
 POST [base]/ServiceRequest
@@ -22,11 +22,11 @@ POST [base]/ServiceRequest
   "reason": [{ "reference": { "reference": "Condition/[id]" } }] }
 ```
 
-### 2. The approval chain (state-insurance only)
+### 2. The approval chain (state-funded only)
 
 This is the central decision rule:
 
-> If `ServiceRequest.coverageKind = state-insurance`, the platform creates a chain of approval `Task`s; otherwise no Task is created and the referral proceeds directly.
+> If the ServiceRequest's PaymentType is `State-funded`, the platform creates a chain of approval `Task`s; otherwise no Task is created and the referral proceeds directly.
 
 Each approval stage is a `Task` referencing the ServiceRequest (`Task.focus`/`basedOn`) with a `Task.code` from the approval category set:
 
@@ -42,7 +42,7 @@ The ServiceRequest and its Tasks stay consistent by these rules:
 
 | Event | Effect |
 |-------|--------|
-| ServiceRequest becomes `active` (state-insurance) | first approval Task created with `status=requested` |
+| ServiceRequest becomes `active` (state-funded) | first approval Task created with `status=requested` |
 | ServiceRequest set `revoked` | all open Tasks set `revoked` |
 | ServiceRequest set `entered-in-error` | all Tasks set `entered-in-error` |
 | Final approval Task `completed` | ServiceRequest set `completed` |

--- a/input/translations/ru/pagecontent/workflow-referral.md
+++ b/input/translations/ru/pagecontent/workflow-referral.md
@@ -6,13 +6,13 @@
 
 > Статус профилей: профили ServiceRequest и Task находятся в разработке. На этой странице описана предполагаемая модель, чтобы системы могли уже сейчас на неё ориентироваться; пока профили не опубликованы, используйте базовые ресурсы FHIR R5 и правила, приведённые ниже. Профилированы [Procedure](StructureDefinition-uz-core-procedure.html), [Observation](StructureDefinition-uz-core-observation.html), [Encounter](StructureDefinition-uz-core-encounter.html) и [Condition](StructureDefinition-uz-core-condition.html), используемые при выполнении.
 
-Участники: направляющий клиницист; комиссии по согласованию (для направлений по государственному страхованию); выполняющее учреждение.
+Участники: направляющий клиницист; комиссии по согласованию (для направлений, финансируемых государством); выполняющее учреждение.
 
 <div>{% include referral-sequence.svg %}</div><br clear="all"/>
 
 ### 1. Создание направления
 
-Клиницист создаёт `ServiceRequest` (`intent = order`), несущий классификацию направления: запрашиваемая услуга в `code`, срочность в `priority` (`routine` \| `urgent` \| `stat`), целевая услуга через `HealthcareService`, клиническое обоснование в `reason` и тип финансирования в расширении `coverageKind` (`state-insurance` \| `insurance` \| `self-payment` \| `other`).
+Клиницист создаёт `ServiceRequest` (`intent = order`), несущий классификацию направления: запрашиваемая услуга в `code`, срочность в `priority` (`routine` \| `urgent` \| `stat`), целевая услуга через `HealthcareService`, клиническое обоснование в `reason` и тип финансирования в расширении [PaymentType](StructureDefinition-payment-type.html) (`Free` \| `Paid` \| `Insurance` \| `State-funded`).
 
 ```
 POST [base]/ServiceRequest
@@ -24,11 +24,11 @@ POST [base]/ServiceRequest
   "reason": [{ "reference": { "reference": "Condition/[id]" } }] }
 ```
 
-### 2. Цепочка согласований (только для государственного страхования)
+### 2. Цепочка согласований (только для финансируемых государством)
 
 Это центральное правило принятия решения:
 
-> Если `ServiceRequest.coverageKind = state-insurance`, платформа создаёт цепочку согласующих `Task`; в противном случае Task не создаётся, и направление выполняется напрямую.
+> Если PaymentType в ServiceRequest равен `State-funded`, платформа создаёт цепочку согласующих `Task`; в противном случае Task не создаётся, и направление выполняется напрямую.
 
 Каждый этап согласования - это `Task`, ссылающийся на ServiceRequest (`Task.focus`/`basedOn`), с `Task.code` из набора категорий согласования:
 
@@ -44,7 +44,7 @@ ServiceRequest и его Task сохраняют согласованность 
 
 | Событие | Эффект |
 |-------|--------|
-| ServiceRequest становится `active` (государственное страхование) | создаётся первый согласующий Task со `status=requested` |
+| ServiceRequest становится `active` (финансируется государством) | создаётся первый согласующий Task со `status=requested` |
 | ServiceRequest установлен в `revoked` | все открытые Task устанавливаются в `revoked` |
 | ServiceRequest установлен в `entered-in-error` | все Task устанавливаются в `entered-in-error` |
 | Финальный согласующий Task `completed` | ServiceRequest устанавливается в `completed` |

--- a/input/translations/uz/pagecontent/workflow-referral.md
+++ b/input/translations/uz/pagecontent/workflow-referral.md
@@ -6,13 +6,13 @@ Ushbu ish jarayoni yo'llanma qanday yaratilishini va bajarilishini ko'rsatadi. Y
 
 > Profil holati: ServiceRequest va Task profillari ishlab chiqilmoqda. Ushbu sahifa mo'ljallangan modellashtirishni tavsiflaydi, shunda tizimlar hozircha shunga asoslanib qurilishi mumkin; profillar e'lon qilinmaguncha, asosiy FHIR R5 resurslaridan va quyidagi qoidalardan foydalaning. Bajarishda ishlatiladigan [Procedure](StructureDefinition-uz-core-procedure.html), [Observation](StructureDefinition-uz-core-observation.html), [Encounter](StructureDefinition-uz-core-encounter.html) va [Condition](StructureDefinition-uz-core-condition.html) profillangan.
 
-Ishtirokchilar: yo'llovchi shifokor; tasdiqlash komissiyalari (davlat sug'urtasi yo'llanmalari uchun); xizmat ko'rsatuvchi muassasa.
+Ishtirokchilar: yo'llovchi shifokor; tasdiqlash komissiyalari (davlat tomonidan moliyalashtiriladigan yo'llanmalar uchun); xizmat ko'rsatuvchi muassasa.
 
 <div>{% include referral-sequence.svg %}</div><br clear="all"/>
 
 ### 1. Yo'llanmani yaratish
 
-Shifokor `ServiceRequest` (`intent = order`) yaratadi va unda yo'llanma tasnifini joylashtiradi: `code` da so'ralayotgan xizmat, `priority` da shoshilinchlik (`routine` \| `urgent` \| `stat`), `HealthcareService` orqali maqsadli xizmat, `reason` da klinik asoslanish va `coverageKind` kengaytmasida moliyalashtirish turi (`state-insurance` \| `insurance` \| `self-payment` \| `other`).
+Shifokor `ServiceRequest` (`intent = order`) yaratadi va unda yo'llanma tasnifini joylashtiradi: `code` da so'ralayotgan xizmat, `priority` da shoshilinchlik (`routine` \| `urgent` \| `stat`), `HealthcareService` orqali maqsadli xizmat, `reason` da klinik asoslanish va [PaymentType](StructureDefinition-payment-type.html) kengaytmasida moliyalashtirish turi (`Free` \| `Paid` \| `Insurance` \| `State-funded`).
 
 ```
 POST [base]/ServiceRequest
@@ -24,11 +24,11 @@ POST [base]/ServiceRequest
   "reason": [{ "reference": { "reference": "Condition/[id]" } }] }
 ```
 
-### 2. Tasdiqlash zanjiri (faqat davlat sug'urtasi)
+### 2. Tasdiqlash zanjiri (faqat davlat tomonidan moliyalashtiriladigan)
 
 Bu markaziy qaror qoidasi:
 
-> Agar `ServiceRequest.coverageKind = state-insurance` bo'lsa, platforma tasdiqlash `Task`lari zanjirini yaratadi; aks holda hech qanday Task yaratilmaydi va yo'llanma to'g'ridan-to'g'ri davom etadi.
+> Agar PaymentType kengaytmasi `State-funded` bo'lsa, platforma tasdiqlash `Task`lari zanjirini yaratadi; aks holda hech qanday Task yaratilmaydi va yo'llanma to'g'ridan-to'g'ri davom etadi.
 
 Har bir tasdiqlash bosqichi ServiceRequest ga (`Task.focus`/`basedOn`) murojaat qiluvchi `Task` bo'lib, uning `Task.code` qiymati tasdiqlash toifalari to'plamidan olinadi:
 
@@ -44,7 +44,7 @@ ServiceRequest va uning Tasklari quyidagi qoidalar orqali bir-biriga mos qoladi:
 
 | Hodisa | Natija |
 |-------|--------|
-| ServiceRequest `active` holatiga o'tadi (davlat sug'urtasi) | birinchi tasdiqlash Task `status=requested` bilan yaratiladi |
+| ServiceRequest `active` holatiga o'tadi (davlat tomonidan moliyalashtiriladigan) | birinchi tasdiqlash Task `status=requested` bilan yaratiladi |
 | ServiceRequest `revoked` qilib belgilanadi | barcha ochiq Tasklar `revoked` qilib belgilanadi |
 | ServiceRequest `entered-in-error` qilib belgilanadi | barcha Tasklar `entered-in-error` qilib belgilanadi |
 | Yakuniy tasdiqlash Task `completed` | ServiceRequest `completed` qilib belgilanadi |


### PR DESCRIPTION
coverageKind was never defined; repoint prose (en/ru/uz) and the sequence diagram to the real PaymentType extension and its codes (Free/Paid/Insurance/State-funded). state-insurance -> state-funded.