### PR TITLE
Mark Patient.managingOrganization as MS

### DIFF
--- a/input/fsh/UZCorePatient.fsh
+++ b/input/fsh/UZCorePatient.fsh
@@ -171,6 +171,7 @@ Description: "Uzbekistan Core Patient profile, used to represent patients admini
 * insert HumanName
 * active MS
 * birthDate MS
+* managingOrganization MS
 
 Instance: example-salim
 InstanceOf: UZCorePatient

--- a/input/fsh/UZCorePatient.fsh
+++ b/input/fsh/UZCorePatient.fsh
@@ -172,6 +172,7 @@ Description: "Uzbekistan Core Patient profile, used to represent patients admini
 * active MS
 * birthDate MS
 * managingOrganization MS
+* managingOrganization only Reference(UZCoreOrganization)
 
 Instance: example-salim
 InstanceOf: UZCorePatient


### PR DESCRIPTION
We already have an MS extension for managingOrganizationAttachment, so managingOrganization itself should be MS as well.

Also constrains `managingOrganization` to `Reference(UZCoreOrganization)` so downstream IGs (e.g. the DHIS2 TB integration) can rely on the parent profile directly instead of re-profiling Patient.