### PR TITLE
Add 0.6.0 to package feed

### DIFF
--- a/docs/package-feed.xml
+++ b/docs/package-feed.xml
@@ -9,7 +9,7 @@
     <description>FHIR Packages published for DHP</description>
     <link>https://raw.githubusercontent.com/uzinfocom-org/digital-health-ig/refs/heads/main/docs/package-feed.xml</link>
     <generator>Manual</generator>
-    <lastBuildDate>Thu, 30 Apr 2026 06:30:16 +0000</lastBuildDate>
+    <lastBuildDate>Mon, 06 Jul 2026 09:18:50 +0000</lastBuildDate>
     <atom:link href="https://raw.githubusercontent.com/uzinfocom-org/digital-health-ig/refs/heads/main/docs/package-feed.xml" rel="self" type="application/rss+xml"/>
     <pubDate>Wed, 27 Aug 2025 12:00:00 +0000</pubDate>
     <language>en</language>
@@ -56,6 +56,17 @@
        <fhir:version>5.0.0</fhir:version>
        <fhir:kind>IG</fhir:kind>
        <pubDate>Thu, 30 Apr 2026 06:30:16 +0000</pubDate>
+     </item>
+
+     <item>
+       <title>uz.dhp.core#0.6.0</title>
+       <description>DHP Implementation Guide Package version 0.6.0</description>
+       <link>https://github.com/uzinfocom-org/digital-health-ig/releases/download/0.6.0/package.tgz</link>
+       <guid isPermaLink="true">https://github.com/uzinfocom-org/digital-health-ig/releases/download/0.6.0/package.tgz</guid>
+       <dc:creator>Vadim Peretokin</dc:creator>
+       <fhir:version>5.0.0</fhir:version>
+       <fhir:kind>IG</fhir:kind>
+       <pubDate>Mon, 06 Jul 2026 09:18:50 +0000</pubDate>
      </item>
 
   </channel>


### PR DESCRIPTION
Adds the `uz.dhp.core#0.6.0` item to the package feed (and bumps `lastBuildDate`) so the FHIR registry discovers 0.6.0. Mirrors #128 (which added 0.5.0).

⚠️ **Order matters — merge this only after the 0.6.0 release exists.** The item links to `releases/download/0.6.0/package.tgz`, which does not exist yet: there is no `0.6.0` GitHub Release/tag or `package.tgz` asset (releases stop at 0.5.0, and nothing automates this). Create the release + upload `package.tgz` first, then merge this so the registry doesn't hit a 404.

`pubDate`/`lastBuildDate` set to `Mon, 06 Jul 2026 09:18:50 +0000`; align with the actual release time if you want them to match exactly.
