### PR TITLE
Add release automation workflow

### DIFF
--- a/.github/scripts/update_package_feed.py
+++ b/.github/scripts/update_package_feed.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Append a version <item> to docs/package-feed.xml (idempotent).
+
+Usage: update_package_feed.py <version> <fhir_version>
+
+Bumps <lastBuildDate> and inserts a new <item> before </channel>, using the
+current UTC time as pubDate. Does nothing if the version is already present.
+"""
+import re
+import sys
+from datetime import datetime, timezone
+
+REPO = "uzinfocom-org/digital-health-ig"
+CREATOR = "Vadim Peretokin"
+FEED = "docs/package-feed.xml"
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("Usage: update_package_feed.py <version> <fhir_version>")
+    version, fhir_version = sys.argv[1], sys.argv[2]
+    title = f"uz.dhp.core#{version}"
+
+    with open(FEED, encoding="utf-8") as f:
+        text = f.read()
+
+    if f"<title>{title}</title>" in text:
+        print(f"{title} already in feed; nothing to do.")
+        return
+
+    now = datetime.now(timezone.utc).strftime("%a, %d %b %Y %H:%M:%S +0000")
+    url = f"https://github.com/{REPO}/releases/download/{version}/package.tgz"
+    item = (
+        "     <item>\n"
+        f"       <title>{title}</title>\n"
+        f"       <description>DHP Implementation Guide Package version {version}</description>\n"
+        f"       <link>{url}</link>\n"
+        f'       <guid isPermaLink="true">{url}</guid>\n'
+        f"       <dc:creator>{CREATOR}</dc:creator>\n"
+        f"       <fhir:version>{fhir_version}</fhir:version>\n"
+        "       <fhir:kind>IG</fhir:kind>\n"
+        f"       <pubDate>{now}</pubDate>\n"
+        "     </item>\n\n"
+    )
+
+    text, n = re.subn(
+        r"<lastBuildDate>.*?</lastBuildDate>",
+        f"<lastBuildDate>{now}</lastBuildDate>",
+        text,
+        count=1,
+    )
+    if n == 0:
+        sys.exit("ERROR: <lastBuildDate> not found in feed")
+
+    marker = "  </channel>"
+    idx = text.rfind(marker)
+    if idx == -1:
+        sys.exit("ERROR: </channel> not found in feed")
+    text = text[:idx] + item + text[idx:]
+
+    with open(FEED, "w", encoding="utf-8") as f:
+        f.write(text)
+    print(f"Added {title} to feed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,105 @@
+name: Release
+
+# Publishes a release when a semver tag (e.g. 0.6.0) is pushed:
+#   1. builds the IG,
+#   2. verifies the built package is uz.dhp.core#<tag>,
+#   3. creates the GitHub Release <tag> with package.tgz attached,
+#   4. opens a PR adding <tag> to docs/package-feed.xml so the FHIR registry
+#      discovers it (main is ruleset-protected, so the feed cannot be pushed
+#      directly).
+# See RELEASING.md.
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      JAVA_TOOL_OPTIONS: "-Xmx8g"
+      # Falls back to GITHUB_TOKEN; if a RELEASE_TOKEN PAT is added later the
+      # feed PR's checks run and it can auto-merge. Otherwise merge it manually.
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN || github.token }}
+      VERSION: ${{ github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN || github.token }}
+
+      - name: Check tag matches sushi-config and release is new
+        run: |
+          CFG_VERSION=$(grep -E '^version:' sushi-config.yaml | awk '{print $2}')
+          echo "Tag: $VERSION | sushi-config.yaml: $CFG_VERSION"
+          if [ "$VERSION" != "$CFG_VERSION" ]; then
+            echo "::error::Tag $VERSION does not match sushi-config version $CFG_VERSION - bump sushi-config first."
+            exit 1
+          fi
+          if gh release view "$VERSION" >/dev/null 2>&1; then
+            echo "::error::Release $VERSION already exists."
+            exit 1
+          fi
+
+      - name: Install Jekyll
+        run: sudo gem install jekyll
+
+      - name: Install Sushi
+        run: sudo npm install -g fsh-sushi
+
+      - name: Install IG publisher
+        run: |
+          chmod +x ./_updatePublisher.sh
+          ./_updatePublisher.sh -y
+
+      - name: Build IG
+        run: |
+          chmod +x ./_genonce.sh
+          ./_genonce.sh
+
+      - name: Verify built package
+        run: |
+          test -f output/package.tgz || { echo "::error::output/package.tgz was not produced"; exit 1; }
+          PKG=$(tar -xzOf output/package.tgz package/package.json)
+          NAME=$(echo "$PKG" | jq -r .name)
+          PVER=$(echo "$PKG" | jq -r .version)
+          echo "Built $NAME#$PVER"
+          if [ "$NAME" != "uz.dhp.core" ] || [ "$PVER" != "$VERSION" ]; then
+            echo "::error::Built package $NAME#$PVER does not match uz.dhp.core#$VERSION"
+            exit 1
+          fi
+
+      - name: Create GitHub release
+        run: |
+          gh release create "$VERSION" output/package.tgz \
+            --title "Version $VERSION" \
+            --notes "Published \`uz.dhp.core#$VERSION\`. See the [changelog](https://dhp.uz/fhir/core/changelog.html)."
+
+      - name: Open package-feed PR
+        run: |
+          FHIR_VERSION=$(grep -E '^fhirVersion:' sushi-config.yaml | awk '{print $2}')
+          BRANCH="chore/package-feed-$VERSION"
+          git fetch origin main
+          git checkout -- . 2>/dev/null || true
+          git checkout -B "$BRANCH" origin/main
+          python3 .github/scripts/update_package_feed.py "$VERSION" "$FHIR_VERSION"
+          if git diff --quiet docs/package-feed.xml; then
+            echo "Feed already contains $VERSION; no PR needed."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/package-feed.xml
+          git commit -m "Add $VERSION to package feed"
+          git push origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "Add $VERSION to package feed" \
+            --body "Automated by the Release workflow: adds \`uz.dhp.core#$VERSION\` to the package feed so the FHIR registry discovers it. Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/$VERSION"
+          gh pr merge --auto --squash "$BRANCH" \
+            || echo "::warning::Auto-merge not enabled on the feed PR - merge it manually."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,32 @@
+# Releasing
+
+Publishing a release is automated by [`.github/workflows/release.yml`](.github/workflows/release.yml).
+
+## Steps
+
+1. **Prepare-release PR.** Open a PR that:
+   - bumps `version:` in `sushi-config.yaml` to `X.Y.Z`, and
+   - rolls the changelog `### In development` section into a `### Version X.Y.Z`
+     section (en/ru/uz), resetting *In development* to `(No changes yet)`.
+
+   Merge it once CI is green.
+
+2. **Tag the release commit** on `main` and push the tag:
+
+   ```bash
+   git checkout main && git pull
+   git tag X.Y.Z && git push origin X.Y.Z
+   ```
+
+3. The **Release** workflow then automatically:
+   - builds the IG,
+   - verifies the built package is `uz.dhp.core#X.Y.Z` (and that the tag matches
+     `sushi-config.yaml`),
+   - creates the GitHub Release `X.Y.Z` with `package.tgz` attached, and
+   - opens a PR adding `X.Y.Z` to [`docs/package-feed.xml`](docs/package-feed.xml)
+     so the FHIR package registry discovers it.
+
+4. **Merge the package-feed PR.**
+
+`main` is ruleset-protected (PR + `sushi`/`ig-publisher` checks required, no
+bypass), so the feed change must go through a PR rather than a direct push.


### PR DESCRIPTION
Automates the release publish (the manual `package.tgz` build + GitHub Release + feed step).

**Trigger:** push a semver tag, e.g. `git push origin 0.7.0`.

**The `Release` workflow then:**
1. builds the IG,
2. verifies the built package is `uz.dhp.core#<tag>` and the tag matches `sushi-config.yaml`,
3. creates the GitHub Release `<tag>` with `package.tgz` attached,
4. opens a PR adding `<tag>` to `docs/package-feed.xml` (idempotent) so the FHIR registry discovers it.

`main` is ruleset-protected (PR + `sushi`/`ig-publisher` required, no bypass), so the feed can't be pushed directly — hence the PR in step 4. Creating the tag/Release is allowed (rulesets target the branch only). Build steps mirror `validate-docs.yml`.

Files: `.github/workflows/release.yml`, `.github/scripts/update_package_feed.py` (tested: idempotent, valid XML), `RELEASING.md`.

Once merged, this can publish 0.6.0: push tag `0.6.0` → workflow does the rest. That supersedes the manual feed PR #231 (close it; the workflow opens its own feed PR).
