### PR TITLE
CI: download IG publisher directly, skip tx.fhir.org landing-page probe

### DIFF
--- a/.github/workflows/validate-docs.yml
+++ b/.github/workflows/validate-docs.yml
@@ -33,15 +33,20 @@ jobs:
       - name: Install Sushi
         run: sudo npm install -g fsh-sushi
 
+      # Download the publisher directly and invoke it without the wrapper scripts:
+      # _updatePublisher.sh and _genonce.sh both probe the tx.fhir.org landing page
+      # and abort (or silently fall back to -tx n/a, skipping terminology validation)
+      # when that page is down even though the terminology API itself is up.
       - name: Install IG publisher
         run: |
-          chmod +x ./_updatePublisher.sh
-          ./_updatePublisher.sh -y
+          mkdir -p input-cache
+          curl -fL --retry 3 --max-time 300 \
+            https://github.com/HL7/fhir-ig-publisher/releases/latest/download/publisher.jar \
+            -o input-cache/publisher.jar
 
       - name: Check that the IG builds successfully
         run: |
-          chmod +x ./_genonce.sh
-          ./_genonce.sh
+          java -Dfile.encoding=UTF-8 -Xmx10g -jar input-cache/publisher.jar -ig .
           echo "✅ IG built successfully"
 
       - name: Check QA report


### PR DESCRIPTION
The `ig-publisher` CI job fails whenever the tx.fhir.org **landing page** is down (e.g. #210 right now), even though the terminology API itself is up: `_updatePublisher.sh` aborts on its landing-page probe, and `_genonce.sh`'s probe silently falls back to `-tx n/a` - disabling the terminology validation the zero-errors QA gate depends on.

Fix: download `publisher.jar` from GitHub releases and run it directly, skipping both probes. If the terminology API is truly down the build now fails loudly instead of passing unvalidated. Local `./_genonce.sh` use is unaffected.

This PR's own `ig-publisher` check tests the change while the landing page is still 404.