### PR TITLE
Add source/target scopes to SSV ConceptMaps

### DIFF
--- a/input/fsh/terminology/SSVLevelTypeToSubordinationGroupCM.fsh
+++ b/input/fsh/terminology/SSVLevelTypeToSubordinationGroupCM.fsh
@@ -8,6 +8,7 @@ Description: "Maps SSV organization level type codes to UZ Core Organizational S
 * status = #draft
 * experimental = false
 * publisher = "Uzinfocom"
+* sourceScopeCanonical = $ssv-organization-type-level
 * targetScopeCanonical = Canonical(OrganizationalSubordinationGroupVS)
 * group.source = $ssv-organization-type-level
 * group.target = Canonical(OrganizationalSubordinationGroupCS)

--- a/input/fsh/terminology/SSVMedicalTypeToNomenclatureGroupCM.fsh
+++ b/input/fsh/terminology/SSVMedicalTypeToNomenclatureGroupCM.fsh
@@ -1,0 +1,56 @@
+Instance: ssv-medical-type-to-nomenclature-group-cm
+InstanceOf: ConceptMap
+Usage: #definition
+Title: "SSV Medical Type to Nomenclature Group"
+Description: "Maps SSV medical type codes to UZ Core Nomenclature Group codes. NomenclatureGroupCS is the Ministry of Health's high-level classification of healthcare institutions by functional category. Only the SSV medical types that correspond directly to a functional category are mapped; for the detailed institution type classification see SSVMedicalTypeToOrganizationalStructureCM."
+* name = "SSVMedicalTypeToNomenclatureGroupCM"
+* url = "https://terminology.dhp.uz/fhir/core/ConceptMap/ssv-medical-type-to-nomenclature-group-cm"
+* status = #draft
+* experimental = false
+* publisher = "Uzinfocom"
+* sourceScopeCanonical = $ssv-organization-type-medical
+* targetScopeCanonical = Canonical(NomenclatureGroupVS)
+* group.source = $ssv-organization-type-medical
+* group.target = Canonical(NomenclatureGroupCS)
+
+* group.element[+].code = #9
+* group.element[=].display = "Disinfection station" // uz: Dezinfektsiya stantsiyasi, ru: Дезинфекционная станция
+* group.element[=].target[+].code = #II_800
+* group.element[=].target[=].display = "Sanitary and epidemiological welfare and health of the population"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #19
+* group.element[=].display = "Pathoanatomic Service" // uz: Patologik xizmat, ru: Патологоанатомическая служба
+* group.element[=].target[+].code = #II_600
+* group.element[=].target[=].display = "Pathological anatomy"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #24
+* group.element[=].display = "Sanatorium" // uz: Sanatoriya, ru: Санаторий
+* group.element[=].target[+].code = #II_400
+* group.element[=].target[=].display = "Resorts"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #25
+* group.element[=].display = "Blood Transfusion station" // uz: Qon quyish stansiyasi, ru: Станция переливания крови
+* group.element[=].target[+].code = #II_700
+* group.element[=].target[=].display = "Blood transfusion center"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #29
+* group.element[=].display = "Blood transfusion facility" // uz: Qon quyish muassasalari, ru: Учреждение переливания крови
+* group.element[=].target[+].code = #II_700
+* group.element[=].target[=].display = "Blood transfusion center"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #31
+* group.element[=].display = "Establishment of sanitary and epidemiological service" // uz: Sanepidxizmati muassasalari, ru: Учреждение санитарно-эпидемиологической службы
+* group.element[=].target[+].code = #II_800
+* group.element[=].target[=].display = "Sanitary and epidemiological welfare and health of the population"
+* group.element[=].target[=].relationship = #equivalent
+
+* group.element[+].code = #36
+* group.element[=].display = "Blood Transfusion Center" // uz: Qon quyish markazi, ru: Центр переливания крови
+* group.element[=].target[+].code = #II_700
+* group.element[=].target[=].display = "Blood transfusion center"
+* group.element[=].target[=].relationship = #equivalent

--- a/input/fsh/terminology/SSVMedicalTypeToOrganizationalStructureCM.fsh
+++ b/input/fsh/terminology/SSVMedicalTypeToOrganizationalStructureCM.fsh
@@ -8,8 +8,9 @@ Description: "Maps SSV medical type codes to UZ Core Organizational Structure co
 * status = #draft
 * experimental = false
 * publisher = "Uzinfocom"
+* sourceScopeCanonical = $ssv-organization-type-medical
+* targetScopeCanonical = Canonical(OrganizationalStructureVS)
 
-// Group 1: SSV mapping to OrganizationalStructureCS
 * group[+].source = $ssv-organization-type-medical
 * group[=].target = Canonical(OrganizationalStructureCS)
 * group[=].element[+].code = #1
@@ -239,48 +240,3 @@ Description: "Maps SSV medical type codes to UZ Core Organizational Structure co
 * group[=].element[=].target[+].code = #355
 * group[=].element[=].target[=].display = "Family doctor point"
 * group[=].element[=].target[=].relationship = #related-to
-
-// Group 2: SSV mapping to NomenclatureGroupCS
-* group[+].source = $ssv-organization-type-medical
-* group[=].target = Canonical(NomenclatureGroupCS)
-* group[=].element[+].code = #9
-* group[=].element[=].display = "Disinfection station" // uz: Dezinfektsiya stantsiyasi, ru: Дезинфекционная станция
-* group[=].element[=].target[+].code = #II_800
-* group[=].element[=].target[=].display = "Sanitary and epidemiological welfare and health of the population"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #19
-* group[=].element[=].display = "Pathoanatomic Service" // uz: Patologik xizmat, ru: Патологоанатомическая служба
-* group[=].element[=].target[+].code = #II_600
-* group[=].element[=].target[=].display = "Pathological anatomy"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #24
-* group[=].element[=].display = "Sanatorium" // uz: Sanatoriya, ru: Санаторий
-* group[=].element[=].target[+].code = #II_400
-* group[=].element[=].target[=].display = "Resorts"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #25
-* group[=].element[=].display = "Blood Transfusion station" // uz: Qon quyish stansiyasi, ru: Станция переливания крови
-* group[=].element[=].target[+].code = #II_700
-* group[=].element[=].target[=].display = "Blood transfusion center"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #29
-* group[=].element[=].display = "Blood transfusion facility" // uz: Qon quyish muassasalari, ru: Учреждение переливания крови
-* group[=].element[=].target[+].code = #II_700
-* group[=].element[=].target[=].display = "Blood transfusion center"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #31
-* group[=].element[=].display = "Establishment of sanitary and epidemiological service" // uz: Sanepidxizmati muassasalari, ru: Учреждение санитарно-эпидемиологической службы
-* group[=].element[=].target[+].code = #II_800
-* group[=].element[=].target[=].display = "Sanitary and epidemiological welfare and health of the population"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target
-
-* group[=].element[+].code = #36
-* group[=].element[=].display = "Blood Transfusion Center" // uz: Qon quyish markazi, ru: Центр переливания крови
-* group[=].element[=].target[+].code = #II_700
-* group[=].element[=].target[=].display = "Blood transfusion center"
-* group[=].element[=].target[=].relationship = #source-is-narrower-than-target

--- a/input/fsh/terminology/SSVServiceTypeToOrganizationalServiceGroupCM.fsh
+++ b/input/fsh/terminology/SSVServiceTypeToOrganizationalServiceGroupCM.fsh
@@ -8,6 +8,7 @@ Description: "Maps SSV service type codes to UZ Core Organizational Service Grou
 * status = #draft
 * experimental = false
 * publisher = "Uzinfocom"
+* sourceScopeCanonical = $ssv-organization-type-service
 * targetScopeCanonical = Canonical(OrganizationalServiceGroupVS)
 * group.source = $ssv-organization-type-service
 * group.target = Canonical(OrganizationalServiceGroupCS)

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -2,7 +2,7 @@
 
 #### Terminology and binding changes
 
-The organization type ConceptMaps have been renamed from the MIS2 prefix to SSV, matching the SSV ValueSets they map from: [SSVLevelTypeToSubordinationGroupCM](ConceptMap-ssv-level-type-to-subordination-group-cm.html), [SSVMedicalTypeToOrganizationalStructureCM](ConceptMap-ssv-medical-type-to-organizational-structure-cm.html) and [SSVServiceTypeToOrganizationalServiceGroupCM](ConceptMap-ssv-service-type-to-organizational-service-group-cm.html). The duplicate `mis2-*` ConceptMaps have been removed; implementers should reference the `ssv-*` canonical URLs.
+The organization type ConceptMaps have been renamed from the MIS2 prefix to SSV, matching the SSV ValueSets they map from: [SSVLevelTypeToSubordinationGroupCM](ConceptMap-ssv-level-type-to-subordination-group-cm.html), [SSVMedicalTypeToOrganizationalStructureCM](ConceptMap-ssv-medical-type-to-organizational-structure-cm.html) and [SSVServiceTypeToOrganizationalServiceGroupCM](ConceptMap-ssv-service-type-to-organizational-service-group-cm.html). The duplicate `mis2-*` ConceptMaps have been removed; implementers should reference the `ssv-*` canonical URLs. The nomenclature group mappings have been split out of SSVMedicalTypeToOrganizationalStructureCM into the new [SSVMedicalTypeToNomenclatureGroupCM](ConceptMap-ssv-medical-type-to-nomenclature-group-cm.html), so that each ConceptMap declares a single source and target scope.
 
 ### Version 0.6.0
 


### PR DESCRIPTION
Stacked on #243.

- Add `sourceScopeCanonical` (SSV ValueSet URLs) to the three SSV organization-type ConceptMaps and `targetScopeCanonical` to the medical one, so pages render "Mapping from X to Y" instead of "Mapping from (not specified) to ...".
- Split the nomenclature mappings out of `SSVMedicalTypeToOrganizationalStructureCM` into the new `SSVMedicalTypeToNomenclatureGroupCM`: with a target scope set, the validator checks every group's target codes against the scope ValueSet, so a ConceptMap mapping into two target systems cannot carry a single scope. Relationships set to `equivalent`.
- `SSVAdministrativeTerritoryToRegionsCM` left without scopes on purpose: its two groups (StateCS, RegionsCS) have no single covering ValueSet, and its per-group headers already render fully.

Local IG publisher build: 0 errors, 0 warnings.