### PR TITLE
Temp stop ObservationCodesVS updated 

### DIFF
--- a/input/fsh/terminology/ObservationCodesVS.fsh
+++ b/input/fsh/terminology/ObservationCodesVS.fsh
@@ -13,3 +13,29 @@ Description: "Codes for observations, allowing use of LOINC, local laboratory co
 * include codes from system $sct where concept is-a #386053000 "Evaluation procedure (procedure)"
 * include codes from system $sct where concept is-a #413350009 "Finding with explicit context (situation)"
 * include codes from system $sct where concept is-a #272379006 "Event (event)"
+
+* include LabPanelCS#lab-pan-A
+* include LabPanelCS#lab-pan-AA
+* include LabPanelCS#lab-pan-B
+* include LabPanelCS#lab-pan-BB 
+* include LabPanelCS#lab-pan-C
+* include LabPanelCS#lab-pan-D
+* include LabPanelCS#lab-pan-E
+* include LabPanelCS#lab-pan-CC 
+* include LabPanelCS#lab-pan-F 
+* include LabPanelCS#lab-pan-G 
+* include LabPanelCS#lab-pan-H
+* include LabPanelCS#lab-pan-I
+* include LabPanelCS#lab-pan-J
+* include LabPanelCS#lab-pan-L
+* include LabPanelCS#lab-pan-M 
+* include LabPanelCS#lab-pan-N 
+* include LabPanelCS#lab-pan-O 
+* include LabPanelCS#lab-pan-P
+* include LabPanelCS#lab-pan-Q
+* include LabPanelCS#lab-pan-R
+* include LabPanelCS#lab-pan-S
+* include LabPanelCS#lab-pan-T 
+* include LabPanelCS#lab-pan-U 
+* include LabPanelCS#lab-pan-V 
+* include LabPanelCS#lab-pan-W 


### PR DESCRIPTION
These changes are necessary to ensure that the data is displayed correctly in the Administrative Panel. It was determined that filtering codes such as lab-pan-A, lab-pan-AA, and so on from codes such as lab-pan-1, lab-pan-2, and so on at the application level is possible, but may negatively affect system performance. Therefore, the required codes were included in a separate ValueSet outside the CodeSystem