### PR TITLE
Dmed vaccine codes and measure units updated

### DIFF
--- a/input/fsh/terminology/DMEDMeasureUnitCM.fsh
+++ b/input/fsh/terminology/DMEDMeasureUnitCM.fsh
@@ -700,3 +700,135 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[+].code = #[iU]
 * group[=].element[=].target[=].display = "international unit"
 * group[=].element[=].target[=].relationship = #related-to
+
+
+// #18 | доля
+* group[=].element[+].code = #18
+* group[=].element[=].display = "доля"
+* group[=].element[=].target[+].code = #%
+* group[=].element[=].target[=].display = "percent"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+
+
+// #51 | Ph.Eur.U.
+* group[=].element[+].code = #51
+* group[=].element[=].display = "Ph.Eur.U."
+* group[=].element[=].target[+].code = #[USP'U]
+* group[=].element[=].target[=].display = "United States Pharmacopeia unit"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #62 | ТУ
+* group[=].element[+].code = #62
+* group[=].element[=].display = "TУ"
+* group[=].element[=].target[+].code = #att
+* group[=].element[=].target[=].display = "technical atmosphere"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+// #143 | мг/3мл
+* group[=].element[+].code = #143
+* group[=].element[=].display = "мг/ 3мл"
+* group[=].element[=].target[+].code = #mg/mL
+* group[=].element[=].target[=].display = "milligram per milliliter"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #340 | мг/4мл
+* group[=].element[+].code = #340
+* group[=].element[=].display = "мг/ 4мл"
+* group[=].element[=].target[+].code = #mg/mL
+* group[=].element[=].target[=].display = "milligram per milliliter"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #359 | мг/200 мл
+* group[=].element[+].code = #359
+* group[=].element[=].display = "мг/ 200 мл"
+* group[=].element[=].target[+].code = #mg/mL
+* group[=].element[=].target[=].display = "milligram per milliliter"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #385 | мг/10мл
+* group[=].element[+].code = #385
+* group[=].element[=].display = "мг/ 10мл"
+* group[=].element[=].target[+].code = #mg/mL
+* group[=].element[=].target[=].display = "milligram per milliliter"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+// #572 | миллиард спор
+* group[=].element[+].code = #572
+* group[=].element[=].display = "миллиард спор"
+* group[=].element[=].target[+].code = #10*9
+* group[=].element[=].target[=].display = "billion"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #611 | часть
+* group[=].element[+].code = #611
+* group[=].element[=].display = "часть"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "one"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #451 | ПЕ
+* group[=].element[+].code = #451
+* group[=].element[=].display = "ПЕ"
+* group[=].element[=].target[+].code = #[PNU]
+* group[=].element[=].target[=].display = "Protein Nitrogen Units"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #19 | доза
+* group[=].element[+].code = #19
+* group[=].element[=].display = "доза"
+* group[=].element[=].target[+].code = #1 
+* group[=].element[=].target[=].display = "1*"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #45 | шт
+* group[=].element[+].code = #45
+* group[=].element[=].display = "шт"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "one"
+* group[=].element[=].target[=].relationship = #related-to
+
+// #20 | клетка
+* group[=].element[+].code = #20
+* group[=].element[=].display = "клетка"
+* group[=].element[=].target[+].code = #[CFU]
+* group[=].element[=].target[=].display = "colony forming unit"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+
+// #66 | ЛД 50
+* group[=].element[+].code = #66
+* group[=].element[=].display = "ЛД 50"
+* group[=].element[=].target[+].code = #mg/kg
+* group[=].element[=].target[=].display = "milligram per kilogram"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+// #485 | qs
+* group[=].element[+].code = #485
+* group[=].element[=].display = "qs"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "1*"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+// #488 | ТФ
+* group[=].element[+].code = #488
+* group[=].element[=].display = "ТФ"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "1*"
+* group[=].element[=].target[=].relationship = #related-to
+
+
+// #612 | степень разведения
+* group[=].element[+].code = #612
+* group[=].element[=].display = "степень разведения"
+* group[=].element[=].target[+].code = #1
+* group[=].element[=].target[=].display = "1*"
+* group[=].element[=].target[=].relationship = #equivalent
+
+

--- a/input/fsh/terminology/DMEDMeasureUnitCM.fsh
+++ b/input/fsh/terminology/DMEDMeasureUnitCM.fsh
@@ -63,6 +63,13 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[=].display = "microgram"
 * group[=].element[=].target[=].relationship = #equivalent
 
+// 565 микрограмм -> ug
+* group[=].element[+].code = #565
+* group[=].element[=].display = "микрограмм"
+* group[=].element[=].target[+].code = #ug
+* group[=].element[=].target[=].display = "microgram"
+* group[=].element[=].target[=].relationship = #equivalent
+
 // 78 микрограмм на дозу -> ug/{dose}
 * group[=].element[+].code = #78
 * group[=].element[=].display = "микрограмм на дозу"
@@ -196,6 +203,7 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[=].display = "milligram per milliliter"
 * group[=].element[=].target[=].relationship = #equivalent
 
+
 // 418 мг/мл -> mg/mL
 * group[=].element[+].code = #418
 * group[=].element[=].display = "мг/мл"
@@ -219,6 +227,20 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 
 // 2 миллиграмм -> mg
 * group[=].element[+].code = #2
+* group[=].element[=].display = "миллиграмм"
+* group[=].element[=].target[+].code = #mg
+* group[=].element[=].target[=].display = "milligram"
+* group[=].element[=].target[=].relationship = #equivalent
+
+// 567 миллиграмм -> mg
+* group[=].element[+].code = #567
+* group[=].element[=].display = "миллиграмм"
+* group[=].element[=].target[+].code = #mg
+* group[=].element[=].target[=].display = "milligram"
+* group[=].element[=].target[=].relationship = #equivalent
+
+// 569 миллиграмм -> mg
+* group[=].element[+].code = #569
 * group[=].element[=].display = "миллиграмм"
 * group[=].element[=].target[+].code = #mg
 * group[=].element[=].target[=].display = "milligram"
@@ -391,6 +413,13 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[+].code = #{spore}
 * group[=].element[=].target[=].display = "spore"
 * group[=].element[=].target[=].relationship = #equivalent
+
+// 23 спора -> {spore}
+* group[=].element[+].code = #495
+* group[=].element[=].display = "спор"
+* group[=].element[=].target[+].code = #{spore}
+* group[=].element[=].target[=].display = "spore"
+* group[=].element[=].target[=].relationship = #related-to
 
 // 610 титр фага -> {phage_titer}
 * group[=].element[+].code = #610
@@ -624,6 +653,13 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[=].display = "colony forming units"
 * group[=].element[=].target[=].relationship = #equivalent
 
+// 54 колониеобразующие единицы -> [CFU]
+* group[=].element[+].code = #54
+* group[=].element[=].display = "колониеобразующие единицы"
+* group[=].element[=].target[+].code = #[CFU]
+* group[=].element[=].target[=].display = "colony forming units"
+* group[=].element[=].target[=].relationship = #equivalent
+
 // 532 млрд КЕ -> [CFU]
 * group[=].element[+].code = #532
 * group[=].element[=].display = "млрд КЕ"
@@ -682,6 +718,13 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 
 // 37 килограмм -> kg
 * group[=].element[+].code = #37
+* group[=].element[=].display = "килограмм"
+* group[=].element[=].target[+].code = #kg
+* group[=].element[=].target[=].display = "kilogram"
+* group[=].element[=].target[=].relationship = #equivalent
+
+// 571 килограмм -> kg
+* group[=].element[+].code = #571
 * group[=].element[=].display = "килограмм"
 * group[=].element[=].target[+].code = #kg
 * group[=].element[=].target[=].display = "kilogram"
@@ -824,11 +867,27 @@ Description: "ConceptMap for mapping DMED  measure unit codes to DHP  measure un
 * group[=].element[=].target[=].relationship = #related-to
 
 
-// #612 | степень разведения
+// #612 степень разведения | 1
 * group[=].element[+].code = #612
 * group[=].element[=].display = "степень разведения"
 * group[=].element[=].target[+].code = #1
 * group[=].element[=].target[=].display = "1*"
+* group[=].element[=].target[=].relationship = #equivalent
+
+
+// #570 микрограмм на миллилитр | microgram per milliliter
+* group[=].element[+].code = #570
+* group[=].element[=].display = "микрограмм на миллилитр"
+* group[=].element[=].target[+].code = #ug/mL
+* group[=].element[=].target[=].display = "microgram per milliliter"
+* group[=].element[=].target[=].relationship = #equivalent
+
+
+// #29 микрограмм на миллилитр | microgram per milliliter
+* group[=].element[+].code = #29
+* group[=].element[=].display = "мкг/мг"
+* group[=].element[=].target[+].code = #ug/mg
+* group[=].element[=].target[=].display = "microgram per milligram"
 * group[=].element[=].target[=].relationship = #equivalent
 
 

--- a/input/fsh/terminology/DMEDVaccineCodesCM.fsh
+++ b/input/fsh/terminology/DMEDVaccineCodesCM.fsh
@@ -665,3 +665,7 @@ Description: "ConceptMap for mapping DMED Vaccine codes to CVX vaccine codes"
 * group[=].element[+].code = #4
 * group[=].element[=].display = "ZF -UZ-VAC (2001 вакцина 202012026)"
 * group[=].element[=].noMap = true
+
+* group[=].element[+].code = #337
+* group[=].element[=].display = "Витамин К"
+* group[=].element[=].noMap = true

--- a/input/manual-fsh/DMEDMeasureUnitCS.fsh
+++ b/input/manual-fsh/DMEDMeasureUnitCS.fsh
@@ -349,3 +349,39 @@ Description: "Measurement unit codes in the DMED system"
 * #612 "степень разведения"
   * ^designation[0].language = #ru
   * ^designation[=].value = "степень разведения"
+
+* #571 "килограмм"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "килограмм"
+
+* #569 "миллиграмм"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "миллиграмм"
+
+* #29 "мкг/мг"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "мкг/мг"
+
+* #570 "микрограмм на миллилитр"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "микрограмм на миллилитр"
+
+* #495 "спор"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "спор"
+
+* #567 "миллиграмм"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "миллиграмм"
+
+* #565 "микрограмм"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "микрограмм"
+
+* #54 "колониеобразующие единицы"
+  * ^designation[0].language = #ru
+  * ^designation[=].value = "колониеобразующие единицы"
+
+
+
+

--- a/input/vocabulary/CodeSystem-dmed-measure-unit-cs.json
+++ b/input/vocabulary/CodeSystem-dmed-measure-unit-cs.json
@@ -1157,11 +1157,91 @@
           "value": "степень разведения"
         }
       ]
+    },
+    {
+      "code": "571",
+      "display": "килограмм",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "килограмм"
+        }
+      ]
+    },
+    {
+      "code": "569",
+      "display": "миллиграмм",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "29",
+      "display": "мкг/мг",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "мкг/мг"
+        }
+      ]
+    },
+    {
+      "code": "570",
+      "display": "микрограмм на миллилитр",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "микрограмм на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "495",
+      "display": "спор",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "спор"
+        }
+      ]
+    },
+    {
+      "code": "567",
+      "display": "миллиграмм",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "565",
+      "display": "микрограмм",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "микрограмм"
+        }
+      ]
+    },
+    {
+      "code": "54",
+      "display": "колониеобразующие единицы",
+      "designation": [
+        {
+          "language": "ru",
+          "value": "колониеобразующие единицы"
+        }
+      ]
     }
   ],
   "caseSensitive": true,
   "hierarchyMeaning": "is-a",
   "language": "uz",
   "experimental": true,
-  "count": 115
+  "count": 123
 }


### PR DESCRIPTION
DMED uses duplicate terminology codes on its side. Therefore, we added these codes to DMEDMeasureUnitCS and DMEDMeasureUnitCM. If they are not added to the corresponding CodeSystem and ConceptMap, the validator will return an error when receiving data from DMED.
