### PR TITLE
Trim always-loaded context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,6 @@
 - **Clean**: `./_build.sh clean` (remove temp directories)
 - **Test**: No specific test framework - validation happens during build
 
-## Architecture
-- **Type**: FHIR R5 Implementation Guide using SUSHI/FSH (FHIR Shorthand)
-- **Main config**: `sushi-config.yaml` (IG metadata, parameters, menu)
-- **IG config**: `ig.ini` (publisher settings)
-- **Source**: `input/` directory containing FSH files, vocabulary, and content
-- **Generated**: `fsh-generated/` (SUSHI output), `output/` (final IG), `temp/` (build temp)
-- **Publisher**: HL7 FHIR IG Publisher (Java-based, stored in `input-cache/`)
-
 ## Code Style & Conventions
 - **FSH files**: Most are located in `input/fsh/` with extra-large codesystems in `input/manual-fsh/`
 - **Vocabulary**: Pre-rendered extra-large codesystems are stored in `input/vocabulary/`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,4 @@ This repository is an HL7 FHIR R5 Implementation Guide authored in FHIR Shorthan
 
 ## Modelling guidelines (required reading)
 
-Before creating or modifying any FHIR profile, extension, value set, code system, instance, or other modelling artifact, read and follow the project modelling guidelines. They define the naming conventions, cardinality rules, binding strengths, slicing patterns, and structural conventions every artifact must follow.
-
-@modelling-guidelines.md
+Before creating or modifying any FHIR profile, extension, value set, code system, instance, or other modelling artifact, you MUST read `modelling-guidelines.md` in full and follow it. It defines the naming conventions, canonical URL patterns, cardinality rules, binding strengths, slicing patterns, terminology and versioning rules, and structural conventions every artifact must follow.


### PR DESCRIPTION
`CLAUDE.md` and everything it `@`-imports is loaded into every session, whether or not that session touches a modelling artifact. That was ~9.2k tokens, and `modelling-guidelines.md` alone was 94% of it.

- **`CLAUDE.md`**: drop the `@modelling-guidelines.md` import, keep the pointer. The instruction to read the guidelines before touching any artifact stays - it's now a MUST and lists what the file covers, so the trigger is at least as strong as before. The file itself is unchanged.
- **`AGENTS.md`**: remove the Architecture block. It listed `sushi-config.yaml`, `ig.ini`, `input/`, `fsh-generated/`, `output/`, `temp/`, `input-cache/` - all visible from `ls`, and the first line duplicated `CLAUDE.md`. Build commands and the conventions section (including the intro-fragment validation gotcha) are untouched, since those aren't derivable.

Net: ~8.7k fewer tokens of always-on context per session, no guidance lost.