### PR TITLE
Fix UCUM supplement translations, duplicates and version

### DIFF
--- a/input/manual-fsh/UCUMUnitsSupplementCS.fsh
+++ b/input/manual-fsh/UCUMUnitsSupplementCS.fsh
@@ -2,7 +2,7 @@ CodeSystem: UCUMUnitsSupplementCS
 Id: ucum-units-supp-cs
 Title: "UCUM Units Supplement Code System"
 Description: "A selected list of UCUM (Unified Code for Units of Measure) units used in laboratory and clinical results. Each concept.code value conforms to the official UCUM syntax defined at http://unitsofmeasure.org. The primary display text is provided in Uzbek, while English and Russian translations are included as designation entries. "
-* insert SupplementCodeSystemDraft(ucum-units-supp-cs, $ucum, 1.5.0)
+* insert SupplementCodeSystemDraft(ucum-units-supp-cs, $ucum, 2.2.0)
 
 * #"10.L/min"
   * ^designation[0].language = #uz
@@ -3616,18 +3616,6 @@ Description: "A selected list of UCUM (Unified Code for Units of Measure) units 
   * ^designation[+].language = #ru
   * ^designation[=].value = "наномоль эквивалента костного коллагена на литр"
 
-* #"nmol/mmol{creat}"
-  * ^designation[0].language = #uz
-  * ^designation[=].value = "nanomol suyak kollageni ekvivalenti/millimol kreatininning"
-  * ^designation[+].language = #ru
-  * ^designation[=].value = "наномоль эквивалента костного коллагена на миллимоль креатинина"
-
-* #"nmol/mg{prot}"
-  * ^designation[0].language = #uz
-  * ^designation[=].value = "nanomol 1/2 sistin/milligramm oqsilning"
-  * ^designation[+].language = #ru
-  * ^designation[=].value = "наномоль 1/2 цистина на миллиграмм белка"
-
 * #"nmol{ATP}"
   * ^designation[0].language = #uz
   * ^designation[=].value = "nanomol ATF"
@@ -5022,57 +5010,57 @@ Description: "A selected list of UCUM (Unified Code for Units of Measure) units 
 
 * #"10*12/L"
   * ^designation[0].language = #uz
-  * ^designation[=].value = "10*12/L"
-  * ^designation[+].language = #ru
-  * ^designation[=].value = "10*12/L"
-
-* #"[oz_tr]"
-  * ^designation[0].language = #uz
   * ^designation[=].value = "trillion/litr"
   * ^designation[+].language = #ru
   * ^designation[=].value = "триллион на литр"
 
-* #"[tb'U]"
+* #"[oz_tr]"
   * ^designation[0].language = #uz
   * ^designation[=].value = "troy untsiyasi"
   * ^designation[+].language = #ru
   * ^designation[=].value = "тройская унция"
 
-* #"V"
+* #"[tb'U]"
   * ^designation[0].language = #uz
   * ^designation[=].value = "tuberkulin birligi"
   * ^designation[+].language = #ru
   * ^designation[=].value = "туберкулиновая единица"
 
-* #"Wb"
+* #"V"
   * ^designation[0].language = #uz
   * ^designation[=].value = "volt"
   * ^designation[+].language = #ru
   * ^designation[=].value = "вольт"
 
-* #"wk"
+* #"Wb"
   * ^designation[0].language = #uz
   * ^designation[=].value = "veber"
   * ^designation[+].language = #ru
   * ^designation[=].value = "вебер"
 
-* #"{WBCs}"
+* #"wk"
   * ^designation[0].language = #uz
   * ^designation[=].value = "hafta"
   * ^designation[+].language = #ru
   * ^designation[=].value = "неделя"
 
-* #"[yd_i]"
+* #"{WBCs}"
   * ^designation[0].language = #uz
   * ^designation[=].value = "leykotsitlar"
   * ^designation[+].language = #ru
   * ^designation[=].value = "лейкоциты"
 
-* #"a"
+* #"[yd_i]"
   * ^designation[0].language = #uz
   * ^designation[=].value = "yard (xalqaro)"
   * ^designation[+].language = #ru
   * ^designation[=].value = "ярд (международный)"
+
+* #"a"
+  * ^designation[0].language = #uz
+  * ^designation[=].value = "yil"
+  * ^designation[+].language = #ru
+  * ^designation[=].value = "год"
 
 * #"{yyyy}"
   * ^designation[0].language = #uz
@@ -5082,9 +5070,9 @@ Description: "A selected list of UCUM (Unified Code for Units of Measure) units 
 
 * #"{Zscore}"
   * ^designation[0].language = #uz
-  * ^designation[=].value = "yil"
+  * ^designation[=].value = "Z-ball"
   * ^designation[+].language = #ru
-  * ^designation[=].value = "год"
+  * ^designation[=].value = "Z-оценка"
 
 * #"[ELU]"
   * ^designation[0].language = #uz

--- a/input/vocabulary/CodeSystem-ucum-units-supp-cs.json
+++ b/input/vocabulary/CodeSystem-ucum-units-supp-cs.json
@@ -1,0 +1,11092 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "draft",
+  "content": "supplement",
+  "name": "UCUMUnitsSupplementCS",
+  "id": "ucum-units-supp-cs",
+  "title": "UCUM Units Supplement Code System",
+  "description": "A selected list of UCUM (Unified Code for Units of Measure) units used in laboratory and clinical results. Each concept.code value conforms to the official UCUM syntax defined at http://unitsofmeasure.org. The primary display text is provided in Uzbek, while English and Russian translations are included as designation entries. ",
+  "url": "https://terminology.dhp.uz/fhir/core/CodeSystem/ucum-units-supp-cs",
+  "concept": [
+    {
+      "code": "10.L/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 litr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "10 литр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "10.L/(min.m2)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 litr/daqiqa/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "10 литр в минуту на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "10.uN.s/(cm5.m2)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 mikronyuton soniya/santimetr beshinchi darajada/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "10 микроньютон секунда на сантиметр в пятой степени на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "10*4/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 ming/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "10 тысяч на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "10*8",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "100 million"
+        },
+        {
+          "language": "ru",
+          "value": "100 миллионов"
+        }
+      ]
+    },
+    {
+      "code": "24.h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "24 часа"
+        }
+      ]
+    },
+    {
+      "code": "{absorbance}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "absorbsiya (optik zichlik)"
+        },
+        {
+          "language": "ru",
+          "value": "оптическая плотность (абсорбция)"
+        }
+      ]
+    },
+    {
+      "code": "{activity}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "faollik"
+        },
+        {
+          "language": "ru",
+          "value": "активность"
+        }
+      ]
+    },
+    {
+      "code": "[AU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "allergiya birligi"
+        },
+        {
+          "language": "ru",
+          "value": "аллергологическая единица"
+        }
+      ]
+    },
+    {
+      "code": "{AHF'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Amerika shifoxona formulari birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Американского госпитального формуляра"
+        }
+      ]
+    },
+    {
+      "code": "A",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "amper"
+        },
+        {
+          "language": "ru",
+          "value": "ампер"
+        }
+      ]
+    },
+    {
+      "code": "A/m",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "amper/metr"
+        },
+        {
+          "language": "ru",
+          "value": "ампер на метр"
+        }
+      ]
+    },
+    {
+      "code": "[arb'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "shartli birlik"
+        },
+        {
+          "language": "ru",
+          "value": "условная единица"
+        }
+      ]
+    },
+    {
+      "code": "[arb'U]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "shartli birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "условная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{ARU}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "aspiringa javob birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица ответа на аспирин"
+        }
+      ]
+    },
+    {
+      "code": "atm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "atmosfera"
+        },
+        {
+          "language": "ru",
+          "value": "атмосфера"
+        }
+      ]
+    },
+    {
+      "code": "ag/{cell}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "attogramm/hujayra"
+        },
+        {
+          "language": "ru",
+          "value": "аттограмм на клетку"
+        }
+      ]
+    },
+    {
+      "code": "bar",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "bar"
+        },
+        {
+          "language": "ru",
+          "value": "бар"
+        }
+      ]
+    },
+    {
+      "code": "Bq",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "bekkerel"
+        },
+        {
+          "language": "ru",
+          "value": "беккерель"
+        }
+      ]
+    },
+    {
+      "code": "[beth'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Betesda birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Бетесда"
+        }
+      ]
+    },
+    {
+      "code": "10*9/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliard/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиард на литр"
+        }
+      ]
+    },
+    {
+      "code": "10*9/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliard/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиард на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "10*9/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliard/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиард на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{binding_index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "bog‘lanish indeksi"
+        },
+        {
+          "language": "ru",
+          "value": "индекс связывания"
+        }
+      ]
+    },
+    {
+      "code": "[bdsk'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Bodanskiy birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Боданского"
+        }
+      ]
+    },
+    {
+      "code": "{breaths}/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqadagi nafas olishlar soni"
+        },
+        {
+          "language": "ru",
+          "value": "дыхательных движений в минуту"
+        }
+      ]
+    },
+    {
+      "code": "{CAG_repeats}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "CAG trinukleotid takrorlari soni"
+        },
+        {
+          "language": "ru",
+          "value": "число повторов тринуклеотида CAG"
+        }
+      ]
+    },
+    {
+      "code": "cal",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kaloriya"
+        },
+        {
+          "language": "ru",
+          "value": "калория"
+        }
+      ]
+    },
+    {
+      "code": "{cells}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "клетки"
+        }
+      ]
+    },
+    {
+      "code": "{cells}/[HPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "hujayralar/katta kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "клетки на поле зрения при большом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "{cells}/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "hujayralar/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "клетки на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "cg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santigramm"
+        },
+        {
+          "language": "ru",
+          "value": "сантиграмм"
+        }
+      ]
+    },
+    {
+      "code": "cL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santilitr"
+        },
+        {
+          "language": "ru",
+          "value": "сантилитр"
+        }
+      ]
+    },
+    {
+      "code": "cm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "cm[Hg]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr of simob ustuni"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр of ртутный столб"
+        }
+      ]
+    },
+    {
+      "code": "cm[H2O]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr of suv ustuni"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр of водный столб"
+        }
+      ]
+    },
+    {
+      "code": "cm[H2O]/L/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr suv ustuni/litr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр водный столб на литр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "cm[H2O]/s/m",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr suv ustuni/soniya/metr"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр водный столб на секунда на метр"
+        }
+      ]
+    },
+    {
+      "code": "cm/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santimetr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "сантиметр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "cP",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santipuaz"
+        },
+        {
+          "language": "ru",
+          "value": "сантипуаз"
+        }
+      ]
+    },
+    {
+      "code": "cSt",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "santistoks"
+        },
+        {
+          "language": "ru",
+          "value": "сантистокс"
+        }
+      ]
+    },
+    {
+      "code": "{delta_OD}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "optik zichlikning o‘zgarishi (delta)"
+        },
+        {
+          "language": "ru",
+          "value": "изменение (дельта) оптической плотности"
+        }
+      ]
+    },
+    {
+      "code": "{clock_time}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "sutka vaqti, masalan 12:30 PM"
+        },
+        {
+          "language": "ru",
+          "value": "время суток, например 12:30 PM"
+        }
+      ]
+    },
+    {
+      "code": "[CFU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "koloniya hosil qiluvchi birlik"
+        },
+        {
+          "language": "ru",
+          "value": "колониеобразующая единица"
+        }
+      ]
+    },
+    {
+      "code": "[CFU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "koloniya hosil qiluvchi birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "колониеобразующая единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "[CFU]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "koloniya hosil qiluvchi birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "колониеобразующая единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{CAE'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "komplement faolligining ferment birligi"
+        },
+        {
+          "language": "ru",
+          "value": "ферментативная единица активности комплемента"
+        }
+      ]
+    },
+    {
+      "code": "{CH100'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "CH100 komplement birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица комплемента CH100"
+        }
+      ]
+    },
+    {
+      "code": "{copies}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nusxalar"
+        },
+        {
+          "language": "ru",
+          "value": "копии"
+        }
+      ]
+    },
+    {
+      "code": "{copies}/ug",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nusxalar/mikrogramm"
+        },
+        {
+          "language": "ru",
+          "value": "копии на микрограмм"
+        }
+      ]
+    },
+    {
+      "code": "{copies}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nusxalar/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "копии на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{count}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "miqdor"
+        },
+        {
+          "language": "ru",
+          "value": "количество"
+        }
+      ]
+    },
+    {
+      "code": "{CPM}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqadagi hisoblar soni"
+        },
+        {
+          "language": "ru",
+          "value": "число импульсов в минуту"
+        }
+      ]
+    },
+    {
+      "code": "{CPM}/10*3{cell}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "counts/daqiqa/ming hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "counts в минуту на тысяча клетки"
+        }
+      ]
+    },
+    {
+      "code": "cm3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kub santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "кубический сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "[cin_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kub dyuym (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "кубический дюйм (международный)"
+        }
+      ]
+    },
+    {
+      "code": "m3/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kub metr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "кубический метр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "{Ct_value}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "sikl chegarasi qiymati"
+        },
+        {
+          "language": "ru",
+          "value": "значение порогового цикла"
+        }
+      ]
+    },
+    {
+      "code": "d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kun"
+        },
+        {
+          "language": "ru",
+          "value": "день"
+        }
+      ]
+    },
+    {
+      "code": "d/(7.d)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kun/7 kun"
+        },
+        {
+          "language": "ru",
+          "value": "день на 7 день"
+        }
+      ]
+    },
+    {
+      "code": "d/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "days/hafta"
+        },
+        {
+          "language": "ru",
+          "value": "days на неделя"
+        }
+      ]
+    },
+    {
+      "code": "dB",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "detsibel"
+        },
+        {
+          "language": "ru",
+          "value": "децибел"
+        }
+      ]
+    },
+    {
+      "code": "dg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "detsigramm"
+        },
+        {
+          "language": "ru",
+          "value": "дециграмм"
+        }
+      ]
+    },
+    {
+      "code": "dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "децилитр"
+        }
+      ]
+    },
+    {
+      "code": "dm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "detsimetr"
+        },
+        {
+          "language": "ru",
+          "value": "дециметр"
+        }
+      ]
+    },
+    {
+      "code": "deg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daraja (tekis burchak)"
+        },
+        {
+          "language": "ru",
+          "value": "градус (плоский угол)"
+        }
+      ]
+    },
+    {
+      "code": "Cel",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Selsiy darajasi"
+        },
+        {
+          "language": "ru",
+          "value": "градус Цельсия"
+        }
+      ]
+    },
+    {
+      "code": "[degF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Farengeyt darajasi"
+        },
+        {
+          "language": "ru",
+          "value": "градус Фаренгейта"
+        }
+      ]
+    },
+    {
+      "code": "K",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kelvin"
+        },
+        {
+          "language": "ru",
+          "value": "кельвин"
+        }
+      ]
+    },
+    {
+      "code": "K/W",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kelvin/vatt"
+        },
+        {
+          "language": "ru",
+          "value": "кельвин на ватт"
+        }
+      ]
+    },
+    {
+      "code": "deg/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daraja/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "градус на секунда"
+        }
+      ]
+    },
+    {
+      "code": "daL/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dekalitr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "декалитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "daL/min/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dekalitr/daqiqa/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "декалитр в минуту на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "{dilution}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "suyultirish"
+        },
+        {
+          "language": "ru",
+          "value": "разведение"
+        }
+      ]
+    },
+    {
+      "code": "[diop]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dioptriya"
+        },
+        {
+          "language": "ru",
+          "value": "диоптрия"
+        }
+      ]
+    },
+    {
+      "code": "[dr_av]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "draxma (AQSh va Buyuk Britaniya)"
+        },
+        {
+          "language": "ru",
+          "value": "драхма (США и Великобритания)"
+        }
+      ]
+    },
+    {
+      "code": "[drp]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "tomchi (1/12 millilitr)"
+        },
+        {
+          "language": "ru",
+          "value": "капля (1/12 миллилитра)"
+        }
+      ]
+    },
+    {
+      "code": "dyn.s/cm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dina soniya/santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "дина секунда на сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "dyn.s/(cm.m2)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dina soniya/santimetr/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "дина секунда на сантиметр на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "{Ehrlich'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Erlix birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Эрлиха"
+        }
+      ]
+    },
+    {
+      "code": "{Ehrlich'U}/100.g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Ehrlich birlik/100 gramm"
+        },
+        {
+          "language": "ru",
+          "value": "Ehrlich единица на 100 грамм"
+        }
+      ]
+    },
+    {
+      "code": "{Ehrlich'U}/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Ehrlich birlik/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "Ehrlich единица на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "{Ehrlich'U}/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Ehrlich birlik/kun"
+        },
+        {
+          "language": "ru",
+          "value": "Ehrlich единица на день"
+        }
+      ]
+    },
+    {
+      "code": "{Ehrlich'U}/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Ehrlich birlik/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "Ehrlich единица на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "{EIA_index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "EIA indeksi"
+        },
+        {
+          "language": "ru",
+          "value": "индекс EIA"
+        }
+      ]
+    },
+    {
+      "code": "{EIA_titer}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "EIA titri"
+        },
+        {
+          "language": "ru",
+          "value": "титр EIA"
+        }
+      ]
+    },
+    {
+      "code": "{EIA'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "EIA birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица EIA"
+        }
+      ]
+    },
+    {
+      "code": "{EIA'U}/U",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "EIA birlik/ferment birlik"
+        },
+        {
+          "language": "ru",
+          "value": "EIA единица на фермент единица"
+        }
+      ]
+    },
+    {
+      "code": "{EV}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "EIA qiymati"
+        },
+        {
+          "language": "ru",
+          "value": "значение EIA"
+        }
+      ]
+    },
+    {
+      "code": "eV",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "elektron-volt"
+        },
+        {
+          "language": "ru",
+          "value": "электронвольт"
+        }
+      ]
+    },
+    {
+      "code": "{ELISA'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ELISA birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица ELISA"
+        }
+      ]
+    },
+    {
+      "code": "U",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birligi"
+        },
+        {
+          "language": "ru",
+          "value": "ферментативная единица"
+        }
+      ]
+    },
+    {
+      "code": "U/10",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/10"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 10"
+        }
+      ]
+    },
+    {
+      "code": "U/10*10",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/10 milliard"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 10 миллиард"
+        }
+      ]
+    },
+    {
+      "code": "U/10*10{cells}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/10 milliard hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 10 миллиард клетки"
+        }
+      ]
+    },
+    {
+      "code": "U/(10.g){feces}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/10 gramm najasning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 10 грамм кала"
+        }
+      ]
+    },
+    {
+      "code": "U/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/12 soat"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 12 час"
+        }
+      ]
+    },
+    {
+      "code": "U/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "U/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "U/10*9",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/milliard"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на миллиард"
+        }
+      ]
+    },
+    {
+      "code": "U/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/kun"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на день"
+        }
+      ]
+    },
+    {
+      "code": "U/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "U/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на грамм"
+        }
+      ]
+    },
+    {
+      "code": "U/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "U/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "U/g{protein}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/gramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на грамм белка"
+        }
+      ]
+    },
+    {
+      "code": "U/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/soat"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на час"
+        }
+      ]
+    },
+    {
+      "code": "U/kg{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/kilogramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на килограмм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "U/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "U{25Cel}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/litr 25 °C da"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на литр при 25 °C"
+        }
+      ]
+    },
+    {
+      "code": "U{37Cel}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/litr 37 °C da"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на литр при 37 °C"
+        }
+      ]
+    },
+    {
+      "code": "U/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "U/mL{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/millilitr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на миллилитр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "U/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "U/10*6",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/million"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на миллион"
+        }
+      ]
+    },
+    {
+      "code": "U/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица в минуту"
+        }
+      ]
+    },
+    {
+      "code": "U/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на секунда"
+        }
+      ]
+    },
+    {
+      "code": "U/10*12",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/trillion"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на триллион"
+        }
+      ]
+    },
+    {
+      "code": "U/10*12{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ferment birlik/trillion eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "фермент единица на триллион эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "eq",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ekvivalent"
+        },
+        {
+          "language": "ru",
+          "value": "эквивалент"
+        }
+      ]
+    },
+    {
+      "code": "eq/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "equivalent/litr"
+        },
+        {
+          "language": "ru",
+          "value": "equivalent на литр"
+        }
+      ]
+    },
+    {
+      "code": "eq/umol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "equivalent/mikromol"
+        },
+        {
+          "language": "ru",
+          "value": "equivalent на микромоль"
+        }
+      ]
+    },
+    {
+      "code": "eq/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "equivalent/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "equivalent на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "eq/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "equivalent/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "equivalent на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "erg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "erg"
+        },
+        {
+          "language": "ru",
+          "value": "эрг"
+        }
+      ]
+    },
+    {
+      "code": "F",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "farad"
+        },
+        {
+          "language": "ru",
+          "value": "фарад"
+        }
+      ]
+    },
+    {
+      "code": "[ft_us]/[ft_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "fut (AQSh)/fut (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "фут (США) на фут (США)"
+        }
+      ]
+    },
+    {
+      "code": "fg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtogramm"
+        },
+        {
+          "language": "ru",
+          "value": "фемтограмм"
+        }
+      ]
+    },
+    {
+      "code": "fL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtolitr"
+        },
+        {
+          "language": "ru",
+          "value": "фемтолитр"
+        }
+      ]
+    },
+    {
+      "code": "fm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtometr"
+        },
+        {
+          "language": "ru",
+          "value": "фемтометр"
+        }
+      ]
+    },
+    {
+      "code": "fmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль"
+        }
+      ]
+    },
+    {
+      "code": "fmol/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на грамм"
+        }
+      ]
+    },
+    {
+      "code": "fmol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "fmol/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "fmol/mg{cyt_prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/milligramm sitozol oqsilining"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на миллиграмм цитозольного белка"
+        }
+      ]
+    },
+    {
+      "code": "fmol/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "fmol/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "femtomol/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "фемтомоль на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[foz_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "suyuq untsiya (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "жидкая унция (США)"
+        }
+      ]
+    },
+    {
+      "code": "{FIU}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "fluoresans intensivligi birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица интенсивности флуоресценции"
+        }
+      ]
+    },
+    {
+      "code": "[ft_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "fut (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "фут (международный)"
+        }
+      ]
+    },
+    {
+      "code": "{fraction}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ulush"
+        },
+        {
+          "language": "ru",
+          "value": "доля"
+        }
+      ]
+    },
+    {
+      "code": "[Ch]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "French (kateter kalibri)"
+        },
+        {
+          "language": "ru",
+          "value": "френч (калибр катетера)"
+        }
+      ]
+    },
+    {
+      "code": "{GAA_repeats}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "GAA trinukleotid takrorlari soni"
+        },
+        {
+          "language": "ru",
+          "value": "число повторов тринуклеотида GAA"
+        }
+      ]
+    },
+    {
+      "code": "[gal_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gallon (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "галлон (США)"
+        }
+      ]
+    },
+    {
+      "code": "{genomes}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "genomlar/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "геномы на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{Globules}/[HPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katta kattalashtirishdagi ko‘rish maydonida globulalar (tomchilar)"
+        },
+        {
+          "language": "ru",
+          "value": "глобулы (капли) в поле зрения при большом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm"
+        },
+        {
+          "language": "ru",
+          "value": "грамм"
+        }
+      ]
+    },
+    {
+      "code": "g.m",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm metr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм метр"
+        }
+      ]
+    },
+    {
+      "code": "g.m/{beat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm metr/yurak urishi"
+        },
+        {
+          "language": "ru",
+          "value": "грамм метр на сердечное сокращение"
+        }
+      ]
+    },
+    {
+      "code": "g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "g{total_nit}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm umumiy azotning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм общего азота"
+        }
+      ]
+    },
+    {
+      "code": "g{total_prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm umumiy oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм общего белка"
+        }
+      ]
+    },
+    {
+      "code": "g{wet_tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm nam to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм влажной ткани"
+        }
+      ]
+    },
+    {
+      "code": "g/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(100.g)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/100 gramm"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 100 грамм"
+        }
+      ]
+    },
+    {
+      "code": "g/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/12 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 12 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(3.d)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/3 kun"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 3 дня"
+        }
+      ]
+    },
+    {
+      "code": "g/(4.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/4 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 4 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(48.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/48 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 48 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(5.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/5 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 5 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(6.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/6 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 6 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(72.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/72 soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 72 час"
+        }
+      ]
+    },
+    {
+      "code": "g/(8.h){shift}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/8 soat shift"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на 8 час shift"
+        }
+      ]
+    },
+    {
+      "code": "g/cm3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kub santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на кубический сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "g/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на день"
+        }
+      ]
+    },
+    {
+      "code": "g/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "g/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на грамм"
+        }
+      ]
+    },
+    {
+      "code": "g/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "g/g{globulin}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/gramm globulin"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на грамм глобулин"
+        }
+      ]
+    },
+    {
+      "code": "g/g{tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/gramm to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на грамм ткани"
+        }
+      ]
+    },
+    {
+      "code": "g/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на час"
+        }
+      ]
+    },
+    {
+      "code": "g/h/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/soat/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на час на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "g/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "g/kg/(8.h){shift}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm/8 soat shift"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм на 8 час shift"
+        }
+      ]
+    },
+    {
+      "code": "g/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "g/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "g/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "g/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на литр"
+        }
+      ]
+    },
+    {
+      "code": "g/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "g/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "g/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "g/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "грамм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "g/mol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/mol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на моль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "g/{specimen}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/namuna"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на образец"
+        }
+      ]
+    },
+    {
+      "code": "g/cm2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kvadrat santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на квадратный сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "g/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "g/{total_output}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/umumiy chiqish"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на общий выход"
+        }
+      ]
+    },
+    {
+      "code": "g/{total_weight}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gramm/umumiy vazn"
+        },
+        {
+          "language": "ru",
+          "value": "грамм на общая масса"
+        }
+      ]
+    },
+    {
+      "code": "Gy",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "grey"
+        },
+        {
+          "language": "ru",
+          "value": "грей"
+        }
+      ]
+    },
+    {
+      "code": "{beats}/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqadagi yurak urishlari soni"
+        },
+        {
+          "language": "ru",
+          "value": "ударов сердца в минуту"
+        }
+      ]
+    },
+    {
+      "code": "H",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "genri"
+        },
+        {
+          "language": "ru",
+          "value": "генри"
+        }
+      ]
+    },
+    {
+      "code": "Hz",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gers"
+        },
+        {
+          "language": "ru",
+          "value": "герц"
+        }
+      ]
+    },
+    {
+      "code": "[HPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katta kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "поле зрения при большом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "soat"
+        },
+        {
+          "language": "ru",
+          "value": "час"
+        }
+      ]
+    },
+    {
+      "code": "h/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "soat/kun"
+        },
+        {
+          "language": "ru",
+          "value": "час на день"
+        }
+      ]
+    },
+    {
+      "code": "h/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "soat/hafta"
+        },
+        {
+          "language": "ru",
+          "value": "час на неделя"
+        }
+      ]
+    },
+    {
+      "code": "[APL'U]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgA kardiolipinga qarshi antitelo birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgA-антител к кардиолипину на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[APL'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgA kardiolipinga qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgA-антител к кардиолипину"
+        }
+      ]
+    },
+    {
+      "code": "{APS'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgA fosfatidilseringa qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgA-антител к фосфатидилсерину"
+        }
+      ]
+    },
+    {
+      "code": "[GPL'U]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgG kardiolipinga qarshi antitelo birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgG-антител к кардиолипину на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[GPL'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgG kardiolipinga qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgG-антител к кардиолипину"
+        }
+      ]
+    },
+    {
+      "code": "{GPS'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgG fosfatidilseringa qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgG-антител к фосфатидилсерину"
+        }
+      ]
+    },
+    {
+      "code": "[MPL'U]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgM kardiolipinga qarshi antitelo birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgM-антител к кардиолипину на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[MPL'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgM kardiolipinga qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgM-антител к кардиолипину"
+        }
+      ]
+    },
+    {
+      "code": "{MPS'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgM fosfatidilseringa qarshi antitelo birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgM-антител к фосфатидилсерину"
+        }
+      ]
+    },
+    {
+      "code": "{MPS'U}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IgM fosfatidilseringa qarshi antitelo birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "единица IgM-антител к фосфатидилсерину на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{ImmuneComplex'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "immun kompleks birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица иммунного комплекса"
+        }
+      ]
+    },
+    {
+      "code": "{ISR}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "immun holat koeffitsiyenti"
+        },
+        {
+          "language": "ru",
+          "value": "коэффициент иммунного статуса"
+        }
+      ]
+    },
+    {
+      "code": "{IFA_index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "immunofluoresans tahlili indeksi"
+        },
+        {
+          "language": "ru",
+          "value": "индекс иммунофлуоресцентного анализа"
+        }
+      ]
+    },
+    {
+      "code": "{IFA_titer}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "immunofluoresans tahlili titri"
+        },
+        {
+          "language": "ru",
+          "value": "титр иммунофлуоресцентного анализа"
+        }
+      ]
+    },
+    {
+      "code": "[in_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dyuym (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "дюйм (международный)"
+        }
+      ]
+    },
+    {
+      "code": "[in_i'H2O]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dyuym (xalqaro) of suv ustuni"
+        },
+        {
+          "language": "ru",
+          "value": "дюйм (международный) of водный столб"
+        }
+      ]
+    },
+    {
+      "code": "[in_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "dyuymlar (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "дюймы (США)"
+        }
+      ]
+    },
+    {
+      "code": "{index_val}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "indeks qiymati"
+        },
+        {
+          "language": "ru",
+          "value": "значение индекса"
+        }
+      ]
+    },
+    {
+      "code": "{index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "indeks qiymati"
+        },
+        {
+          "language": "ru",
+          "value": "значение индекса"
+        }
+      ]
+    },
+    {
+      "code": "{HA_titer}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "gripp virusi gemagglutinatsiya titri"
+        },
+        {
+          "language": "ru",
+          "value": "титр гемагглютинации вируса гриппа"
+        }
+      ]
+    },
+    {
+      "code": "{INR}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "xalqaro normallashtirilgan nisbat"
+        },
+        {
+          "language": "ru",
+          "value": "международное нормализованное отношение"
+        }
+      ]
+    },
+    {
+      "code": "[IU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "xalqaro birlik"
+        },
+        {
+          "language": "ru",
+          "value": "международная единица"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/10*9{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/milliard eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на миллиард эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/kun"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на день"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на грамм"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/soat"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на час"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/L{37Cel}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/litr 37 °C da"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на литр при 37 °C"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "international единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[IU]/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "international birlik/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "international единица в минуту"
+        }
+      ]
+    },
+    {
+      "code": "J",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "joul"
+        },
+        {
+          "language": "ru",
+          "value": "джоуль"
+        }
+      ]
+    },
+    {
+      "code": "J/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "joul/litr"
+        },
+        {
+          "language": "ru",
+          "value": "джоуль на литр"
+        }
+      ]
+    },
+    {
+      "code": "{JDF'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Yuvenil diabet fondi birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Фонда ювенильного диабета"
+        }
+      ]
+    },
+    {
+      "code": "{JDF'U}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Juvenile Diabetes Foundation birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "Juvenile Diabetes Foundation единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "{KCT'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kaolin bilan ivish vaqti"
+        },
+        {
+          "language": "ru",
+          "value": "время свертывания с каолином"
+        }
+      ]
+    },
+    {
+      "code": "kat",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katal"
+        },
+        {
+          "language": "ru",
+          "value": "катал"
+        }
+      ]
+    },
+    {
+      "code": "kat/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katal/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "катал на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "kat/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katal/litr"
+        },
+        {
+          "language": "ru",
+          "value": "катал на литр"
+        }
+      ]
+    },
+    {
+      "code": "kU",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloferment birligi"
+        },
+        {
+          "language": "ru",
+          "value": "килоферментативная единица"
+        }
+      ]
+    },
+    {
+      "code": "kU/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloferment birligi/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "килоферментативная единица на грамм"
+        }
+      ]
+    },
+    {
+      "code": "kU/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloferment birligi/litr"
+        },
+        {
+          "language": "ru",
+          "value": "килоферментативная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "kU/L{class}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloferment birligi/litr sinf"
+        },
+        {
+          "language": "ru",
+          "value": "килоферментативная единица на литр класс"
+        }
+      ]
+    },
+    {
+      "code": "kU/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloferment birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "килоферментативная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "k[IU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloxalqaro birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "киломеждународная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "k[IU]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kiloxalqaro birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "киломеждународная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "kcal",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория"
+        }
+      ]
+    },
+    {
+      "code": "kcal/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "kcal/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya/kun"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория на день"
+        }
+      ]
+    },
+    {
+      "code": "kcal/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya/soat"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория на час"
+        }
+      ]
+    },
+    {
+      "code": "kcal/kg/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya/kilogramm/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория на килограмм на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "kcal/[oz_av]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilokaloriya/ounce (US & British)"
+        },
+        {
+          "language": "ru",
+          "value": "килокалория на ounce (US & British)"
+        }
+      ]
+    },
+    {
+      "code": "kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм"
+        }
+      ]
+    },
+    {
+      "code": "kg.m/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm metr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм метр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "kg/m3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/kub metr"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на кубический метр"
+        }
+      ]
+    },
+    {
+      "code": "kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "kg/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "kg/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/mol"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на моль"
+        }
+      ]
+    },
+    {
+      "code": "kg/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на секунда"
+        }
+      ]
+    },
+    {
+      "code": "kg/(s.m2)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/soniya/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на секунда на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "kg/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilogramm/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "килограмм на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "kL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilolitr"
+        },
+        {
+          "language": "ru",
+          "value": "килолитр"
+        }
+      ]
+    },
+    {
+      "code": "km",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilometr"
+        },
+        {
+          "language": "ru",
+          "value": "километр"
+        }
+      ]
+    },
+    {
+      "code": "kPa",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilopaskal"
+        },
+        {
+          "language": "ru",
+          "value": "килопаскаль"
+        }
+      ]
+    },
+    {
+      "code": "ks",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kilosekund"
+        },
+        {
+          "language": "ru",
+          "value": "килосекунда"
+        }
+      ]
+    },
+    {
+      "code": "[ka'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "King–Armstrong birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Кинга—Армстронга"
+        }
+      ]
+    },
+    {
+      "code": "{KRONU'U}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Kronus birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "единица Kronus на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "[knk'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Kunkel birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Кункеля"
+        }
+      ]
+    },
+    {
+      "code": "L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr"
+        },
+        {
+          "language": "ru",
+          "value": "литр"
+        }
+      ]
+    },
+    {
+      "code": "L/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "литр на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "L/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "литр на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "L/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/kun"
+        },
+        {
+          "language": "ru",
+          "value": "литр на день"
+        }
+      ]
+    },
+    {
+      "code": "L/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "литр на час"
+        }
+      ]
+    },
+    {
+      "code": "L/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "литр на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "L/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/litr"
+        },
+        {
+          "language": "ru",
+          "value": "литр на литр"
+        }
+      ]
+    },
+    {
+      "code": "L/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "литр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "L/min/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/daqiqa/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "литр в минуту на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "L/(min.m2)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/daqiqa/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "литр в минуту на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "L/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "литр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "L/s/s2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "litr/soniya/kvadrat soniya"
+        },
+        {
+          "language": "ru",
+          "value": "литр на секунда на квадратная секунда"
+        }
+      ]
+    },
+    {
+      "code": "{Log_copies}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nusxalarning 10 asosli logarifmi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "логарифм (по основанию 10) копий на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{Log_IU}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "xalqaro birliklarning 10 asosli logarifmi"
+        },
+        {
+          "language": "ru",
+          "value": "логарифм (по основанию 10) международных единиц"
+        }
+      ]
+    },
+    {
+      "code": "{Log_IU}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "xalqaro birliklarning 10 asosli logarifmi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "логарифм (по основанию 10) международных единиц на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{Log}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 asosli logarifm"
+        },
+        {
+          "language": "ru",
+          "value": "логарифм по основанию 10"
+        }
+      ]
+    },
+    {
+      "code": "[LPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kichik kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "поле зрения при малом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "lm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "lyumen"
+        },
+        {
+          "language": "ru",
+          "value": "люмен"
+        }
+      ]
+    },
+    {
+      "code": "lm.m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "lyumen-kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "люмен-квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "{Lyme_index_value}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Laym indeksi qiymati"
+        },
+        {
+          "language": "ru",
+          "value": "значение индекса Лайма"
+        }
+      ]
+    },
+    {
+      "code": "[mclg'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Maklagan birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Маклагана"
+        }
+      ]
+    },
+    {
+      "code": "Ms",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "megasekund"
+        },
+        {
+          "language": "ru",
+          "value": "мегасекунда"
+        }
+      ]
+    },
+    {
+      "code": "[MET].min/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "haftasiga metabolik ekvivalent-daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "метаболический эквивалент-минута в неделю"
+        }
+      ]
+    },
+    {
+      "code": "m",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "metr"
+        },
+        {
+          "language": "ru",
+          "value": "метр"
+        }
+      ]
+    },
+    {
+      "code": "m/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "metr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "метр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "m/s2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "metr/kvadrat soniya"
+        },
+        {
+          "language": "ru",
+          "value": "метр на квадратная секунда"
+        }
+      ]
+    },
+    {
+      "code": "t",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "metrik tonna"
+        },
+        {
+          "language": "ru",
+          "value": "метрическая тонна"
+        }
+      ]
+    },
+    {
+      "code": "uU/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroferment birligi/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "микроферментативная единица на грамм"
+        }
+      ]
+    },
+    {
+      "code": "uU/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroferment birligi/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микроферментативная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "uU/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroferment birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микроферментативная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "u[IU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroxalqaro birlik"
+        },
+        {
+          "language": "ru",
+          "value": "микромеждународная единица"
+        }
+      ]
+    },
+    {
+      "code": "u[IU]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroxalqaro birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микромеждународная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "ueq",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroekvivalent"
+        },
+        {
+          "language": "ru",
+          "value": "микроэквивалент"
+        }
+      ]
+    },
+    {
+      "code": "ueq/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroekvivalent/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микроэквивалент на литр"
+        }
+      ]
+    },
+    {
+      "code": "ueq/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroekvivalent/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микроэквивалент на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "ug",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{feces}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm najasning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм кала"
+        }
+      ]
+    },
+    {
+      "code": "ug{FEU}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm fibrinogen ekvivalent birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм фибриноген-эквивалентных единиц на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "ug/(100.g)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/100 gramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на 100 грамм"
+        }
+      ]
+    },
+    {
+      "code": "ug/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "ug/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "ug/m3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kub metr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на кубический метр"
+        }
+      ]
+    },
+    {
+      "code": "ug/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "ug/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "ug/dL{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/detsilitr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на децилитр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "ug/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{dry_tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm quruq to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм сухой ткани"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{dry_wt}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm quruq massaning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм сухой массы"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{hair}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm sochning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм волос"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "ug/g{tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/gramm to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на грамм ткани"
+        }
+      ]
+    },
+    {
+      "code": "ug/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "ug/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "ug/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "ug/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "ug/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "ug/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "ug/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "ug/L{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/litr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на литр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "ug/L/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/litr/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на литр на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "ug/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "ug/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "ug/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "ug/mL{class}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/millilitr sinf"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллилитр класс"
+        }
+      ]
+    },
+    {
+      "code": "ug/mL{eqv}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/millilitr equivalent"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллилитр equivalent"
+        }
+      ]
+    },
+    {
+      "code": "ug/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "ug/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "ug/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "ug/ng",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/nanogramm"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на нанограмм"
+        }
+      ]
+    },
+    {
+      "code": "ug/{specimen}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/namuna"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на образец"
+        }
+      ]
+    },
+    {
+      "code": "ug/[sft_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kvadrat fut (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на квадратный фут (международный)"
+        }
+      ]
+    },
+    {
+      "code": "ug/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrogramm/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "микрограмм на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "u[IU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroxalqaro birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микромеждународная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "ukat",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrokatal"
+        },
+        {
+          "language": "ru",
+          "value": "микрокатал"
+        }
+      ]
+    },
+    {
+      "code": "uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "микролитр"
+        }
+      ]
+    },
+    {
+      "code": "uL/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrolitr/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микролитр на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "uL/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrolitr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "микролитр на час"
+        }
+      ]
+    },
+    {
+      "code": "um",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrometr"
+        },
+        {
+          "language": "ru",
+          "value": "микрометр"
+        }
+      ]
+    },
+    {
+      "code": "umol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль"
+        }
+      ]
+    },
+    {
+      "code": "umol{BCE}/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol suyak kollageni ekvivalenti/mol"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль эквивалента костного коллагена на моль"
+        }
+      ]
+    },
+    {
+      "code": "umol/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "umol/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "umol/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "umol/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/kun"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на день"
+        }
+      ]
+    },
+    {
+      "code": "umol/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "umol/dL{GF}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/detsilitr glomerulyar filtratning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на децилитр клубочкового фильтрата"
+        }
+      ]
+    },
+    {
+      "code": "umol/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на грамм"
+        }
+      ]
+    },
+    {
+      "code": "umol/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "umol/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "umol/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/soat"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на час"
+        }
+      ]
+    },
+    {
+      "code": "umol/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "umol/kg{feces}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/kilogramm najasning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на килограмм кала"
+        }
+      ]
+    },
+    {
+      "code": "umol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "umol/L{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/litr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на литр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "umol/L/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/litr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на литр на час"
+        }
+      ]
+    },
+    {
+      "code": "umol/umol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/mikromol"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на микромоль"
+        }
+      ]
+    },
+    {
+      "code": "umol/umol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/mikromol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на микромоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "umol/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "umol/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "umol/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "umol/mL/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/millilitr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллилитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "umol/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "umol/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "umol/10*6{RBC}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/million eritrotsit"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на миллион эритроцит"
+        }
+      ]
+    },
+    {
+      "code": "umol/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль в минуту"
+        }
+      ]
+    },
+    {
+      "code": "umol/min/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/daqiqa/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль в минуту на грамм"
+        }
+      ]
+    },
+    {
+      "code": "umol/min/g{mucosa}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/daqiqa/gramm shilliq qavatning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль в минуту на грамм слизистой оболочки"
+        }
+      ]
+    },
+    {
+      "code": "umol/min/g{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/daqiqa/gramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль в минуту на грамм белка"
+        }
+      ]
+    },
+    {
+      "code": "umol/min/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/daqiqa/litr"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль в минуту на литр"
+        }
+      ]
+    },
+    {
+      "code": "umol/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/mol"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на моль"
+        }
+      ]
+    },
+    {
+      "code": "umol/mol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/mol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на моль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "umol/mol{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikromol/mol gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "микромоль на моль гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "um/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikronlar/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "микроны на секунда"
+        }
+      ]
+    },
+    {
+      "code": "uOhm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikroom"
+        },
+        {
+          "language": "ru",
+          "value": "микроом"
+        }
+      ]
+    },
+    {
+      "code": "us",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrosoniya"
+        },
+        {
+          "language": "ru",
+          "value": "микросекунда"
+        }
+      ]
+    },
+    {
+      "code": "uV",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrovolt"
+        },
+        {
+          "language": "ru",
+          "value": "микровольт"
+        }
+      ]
+    },
+    {
+      "code": "[mi_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milya (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "миля (международная)"
+        }
+      ]
+    },
+    {
+      "code": "mU/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на грамм"
+        }
+      ]
+    },
+    {
+      "code": "mU/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mU/mL/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/millilitr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллилитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mU/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mU/mmol{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/millimol eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллимоль эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "m[IU]/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millixalqaro birlik/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимеждународная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mU/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "mU/g{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/gramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на грамм белка"
+        }
+      ]
+    },
+    {
+      "code": "mU/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "mU/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "mU/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliferment birligi/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиферментативная единица на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "m[IU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millixalqaro birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимеждународная единица на литр"
+        }
+      ]
+    },
+    {
+      "code": "mA",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliamper"
+        },
+        {
+          "language": "ru",
+          "value": "миллиампер"
+        }
+      ]
+    },
+    {
+      "code": "mbar",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millibar"
+        },
+        {
+          "language": "ru",
+          "value": "миллибар"
+        }
+      ]
+    },
+    {
+      "code": "mbar/L/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millibar/litr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "миллибар на литр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "mbar.s/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millibar soniya/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллибар секунда на литр"
+        }
+      ]
+    },
+    {
+      "code": "meq",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент"
+        }
+      ]
+    },
+    {
+      "code": "meq/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "meq/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "meq/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "meq/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на день"
+        }
+      ]
+    },
+    {
+      "code": "meq/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "meq/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на грамм"
+        }
+      ]
+    },
+    {
+      "code": "meq/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "meq/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на час"
+        }
+      ]
+    },
+    {
+      "code": "meq/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "meq/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "meq/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на литр"
+        }
+      ]
+    },
+    {
+      "code": "meq/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "meq/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент в минуту"
+        }
+      ]
+    },
+    {
+      "code": "meq/{specimen}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/namuna"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на образец"
+        }
+      ]
+    },
+    {
+      "code": "meq/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "meq/{total_volume}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliekvivalent/umumiy hajm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиэквивалент на общий объем"
+        }
+      ]
+    },
+    {
+      "code": "mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "mg{FEU}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm fibrinogen ekvivalent birligi/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм фибриноген-эквивалентных единиц на литр"
+        }
+      ]
+    },
+    {
+      "code": "mg/(10.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/10 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 10 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/12 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 12 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(6.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/6 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 6 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(72.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/72 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 72 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/{collection}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/yig‘ish"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на сбор"
+        }
+      ]
+    },
+    {
+      "code": "mg/m3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kub metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на кубический метр"
+        }
+      ]
+    },
+    {
+      "code": "mg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на день"
+        }
+      ]
+    },
+    {
+      "code": "mg/d/{1.73_m2}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kun/1.73 kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на день на 1.73 квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mg/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "mg/dL{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/detsilitr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на децилитр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "mg/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм"
+        }
+      ]
+    },
+    {
+      "code": "mg/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mg/g{dry_tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm quruq to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм сухой ткани"
+        }
+      ]
+    },
+    {
+      "code": "mg/g{feces}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm najasning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм кала"
+        }
+      ]
+    },
+    {
+      "code": "mg/g{tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм ткани"
+        }
+      ]
+    },
+    {
+      "code": "mg/g{wet_tissue}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/gramm nam to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на грамм влажной ткани"
+        }
+      ]
+    },
+    {
+      "code": "mg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на час"
+        }
+      ]
+    },
+    {
+      "code": "mg/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mg/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mg/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "mg/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "mg/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mg/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "mg/L{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/litr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на литр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "mg/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "mg/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mg/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mg/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "mg/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mg/{specimen}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/namuna"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на образец"
+        }
+      ]
+    },
+    {
+      "code": "mg/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mg/{total_output}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/umumiy chiqish"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на общий выход"
+        }
+      ]
+    },
+    {
+      "code": "mg/{total_volume}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/umumiy hajm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на общий объем"
+        }
+      ]
+    },
+    {
+      "code": "mg/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milligramm/hafta"
+        },
+        {
+          "language": "ru",
+          "value": "миллиграмм на неделя"
+        }
+      ]
+    },
+    {
+      "code": "mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mL{fetal_RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr fetal eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр фетальных эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "mL/(10.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/10 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 10 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/12 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 12 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(4.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/4 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 4 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(5.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/5 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 5 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(6.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/6 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 6 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(72.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/72 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 72 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/(8.h)/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/8 soat/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на 8 час на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mL/cm[H2O]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/santimetr suv ustuni"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на сантиметр водный столб"
+        }
+      ]
+    },
+    {
+      "code": "mL/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на день"
+        }
+      ]
+    },
+    {
+      "code": "mL/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "mL/{beat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/yurak urishi"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на сердечное сокращение"
+        }
+      ]
+    },
+    {
+      "code": "mL/{beat}/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/yurak urishi/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на сердечное сокращение на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mL/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на час"
+        }
+      ]
+    },
+    {
+      "code": "mL/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mL/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mL/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "mL/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "mL/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mL/mbar",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/millibar"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на миллибар"
+        }
+      ]
+    },
+    {
+      "code": "mL/mm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/millimetr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на миллиметр"
+        }
+      ]
+    },
+    {
+      "code": "mL/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mL/min/{1.73_m2}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/daqiqa/1.73 kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр в минуту на 1.73 квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mL/min/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/daqiqa/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр в минуту на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mL/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "mL/[sin_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kvadrat dyuym (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на квадратный дюйм (международный)"
+        }
+      ]
+    },
+    {
+      "code": "mL/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitr/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллилитр на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimetr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиметр"
+        }
+      ]
+    },
+    {
+      "code": "mm[Hg]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "simob ustunining millimetri"
+        },
+        {
+          "language": "ru",
+          "value": "миллиметр ртутного столба"
+        }
+      ]
+    },
+    {
+      "code": "mm[H2O]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "suv ustunining millimetri"
+        },
+        {
+          "language": "ru",
+          "value": "миллиметр водного столба"
+        }
+      ]
+    },
+    {
+      "code": "mm/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimetr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллиметр на час"
+        }
+      ]
+    },
+    {
+      "code": "mm/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimetr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллиметр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/12 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 12 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(2.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/2 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 2 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(5.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/5 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 5 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(6.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/6 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 6 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на день"
+        }
+      ]
+    },
+    {
+      "code": "mmol/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "mmol/{ejaculate}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/eyakulyat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на эякулят"
+        }
+      ]
+    },
+    {
+      "code": "mmol/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на грамм"
+        }
+      ]
+    },
+    {
+      "code": "mmol/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mmol/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/h/mg{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/soat/milligramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на час на миллиграмм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "mmol/h/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/soat/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на час на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "mmol/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mmol/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/kg/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kilogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на килограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "mmol/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "mmol/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mmol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "mmol/L{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/litr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на литр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mmol{urea}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/millimol mochevina"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на миллимоль мочевина"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/millmole kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на millmole креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mmol/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль в минуту"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/mol"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на моль"
+        }
+      ]
+    },
+    {
+      "code": "mmol/mol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/mol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на моль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "mmol/s/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/soniya/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на секунда на литр"
+        }
+      ]
+    },
+    {
+      "code": "mmol/{specimen}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/namuna"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на образец"
+        }
+      ]
+    },
+    {
+      "code": "mmol/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "mmol/{total_vol}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millimol/umumiy hajm"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на общий объем"
+        }
+      ]
+    },
+    {
+      "code": "10*6",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million"
+        },
+        {
+          "language": "ru",
+          "value": "миллион"
+        }
+      ]
+    },
+    {
+      "code": "10*6.[CFU]/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million koloniya hosil qiluvchi birlik/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллион колониеобразующих единиц на литр"
+        }
+      ]
+    },
+    {
+      "code": "10*6.[IU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million xalqaro birlik"
+        },
+        {
+          "language": "ru",
+          "value": "миллион международных единиц"
+        }
+      ]
+    },
+    {
+      "code": "10*6/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "миллион на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "10*6/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллион на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "10*6/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллион на литр"
+        }
+      ]
+    },
+    {
+      "code": "10*6/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллион на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "10*6/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "million/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "миллион на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mosm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliosmol"
+        },
+        {
+          "language": "ru",
+          "value": "миллиосмоль"
+        }
+      ]
+    },
+    {
+      "code": "mosm/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliosmol/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "миллиосмоль на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mosm/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliosmol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "миллиосмоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "mPa",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millipaskal"
+        },
+        {
+          "language": "ru",
+          "value": "миллипаскаль"
+        }
+      ]
+    },
+    {
+      "code": "mPa.s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millipaskal soniya"
+        },
+        {
+          "language": "ru",
+          "value": "миллипаскаль секунда"
+        }
+      ]
+    },
+    {
+      "code": "ms",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millisoniya"
+        },
+        {
+          "language": "ru",
+          "value": "миллисекунда"
+        }
+      ]
+    },
+    {
+      "code": "mV",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millivolt"
+        },
+        {
+          "language": "ru",
+          "value": "милливольт"
+        }
+      ]
+    },
+    {
+      "code": "mV/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millivolt/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "милливольт на секунда"
+        }
+      ]
+    },
+    {
+      "code": "{minidrop}/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrotomchi/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "микрокапля в минуту"
+        }
+      ]
+    },
+    {
+      "code": "{minidrop}/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrotomchi/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "микрокапля на секунда"
+        }
+      ]
+    },
+    {
+      "code": "min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "минута"
+        }
+      ]
+    },
+    {
+      "code": "min/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqa/kun"
+        },
+        {
+          "language": "ru",
+          "value": "минута на день"
+        }
+      ]
+    },
+    {
+      "code": "min/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "daqiqa/hafta"
+        },
+        {
+          "language": "ru",
+          "value": "минута на неделя"
+        }
+      ]
+    },
+    {
+      "code": "mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol"
+        },
+        {
+          "language": "ru",
+          "value": "моль"
+        }
+      ]
+    },
+    {
+      "code": "mol/m3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/kub metr"
+        },
+        {
+          "language": "ru",
+          "value": "моль на кубический метр"
+        }
+      ]
+    },
+    {
+      "code": "mol/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "моль на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "mol/kg/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/kilogramm/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "моль на килограмм на секунда"
+        }
+      ]
+    },
+    {
+      "code": "mol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "моль на литр"
+        }
+      ]
+    },
+    {
+      "code": "mol/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "моль на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "mol/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/mol"
+        },
+        {
+          "language": "ru",
+          "value": "моль на моль"
+        }
+      ]
+    },
+    {
+      "code": "mol/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mol/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "моль на секунда"
+        }
+      ]
+    },
+    {
+      "code": "{#}/{platelet}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "molekula/trombotsit"
+        },
+        {
+          "language": "ru",
+          "value": "молекула на тромбоцит"
+        }
+      ]
+    },
+    {
+      "code": "mo",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "oy"
+        },
+        {
+          "language": "ru",
+          "value": "месяц"
+        }
+      ]
+    },
+    {
+      "code": "{mm/dd/yyyy}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "oy-kun-yil"
+        },
+        {
+          "language": "ru",
+          "value": "месяц-день-год"
+        }
+      ]
+    },
+    {
+      "code": "{M.o.M}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "medianaga karralik"
+        },
+        {
+          "language": "ru",
+          "value": "кратность медианы"
+        }
+      ]
+    },
+    {
+      "code": "{mutation}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mutatsiya"
+        },
+        {
+          "language": "ru",
+          "value": "мутация"
+        }
+      ]
+    },
+    {
+      "code": "nU/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanoferment birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "наноферментативная единица на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "nU/{RBC}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanoferment birligi/eritrotsit"
+        },
+        {
+          "language": "ru",
+          "value": "наноферментативная единица на эритроцит"
+        }
+      ]
+    },
+    {
+      "code": "ng",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм"
+        }
+      ]
+    },
+    {
+      "code": "ng{FEU}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm fibrinogen ekvivalent birligi/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм фибриноген-эквивалентных единиц на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "ng/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "ng/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "ng/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kun"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на день"
+        }
+      ]
+    },
+    {
+      "code": "ng/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "ng/U",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/ferment birlik"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на фермент единица"
+        }
+      ]
+    },
+    {
+      "code": "ng/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на грамм"
+        }
+      ]
+    },
+    {
+      "code": "ng/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "ng/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "ng/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "ng/kg/(8.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kilogramm/8 soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на килограмм на 8 час"
+        }
+      ]
+    },
+    {
+      "code": "ng/kg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kilogramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на килограмм на час"
+        }
+      ]
+    },
+    {
+      "code": "ng/kg/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kilogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на килограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "ng/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "ng/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "ng/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "ng/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "ng/mg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/milligramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллиграмм на час"
+        }
+      ]
+    },
+    {
+      "code": "ng/mL{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/millilitr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллилитр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "ng/mL/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/millilitr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллилитр на час"
+        }
+      ]
+    },
+    {
+      "code": "ng/10*6",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/million"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллион"
+        }
+      ]
+    },
+    {
+      "code": "ng/10*6{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/million eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на миллион эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "ng/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/millliiter"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на millliiter"
+        }
+      ]
+    },
+    {
+      "code": "ng/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм в минуту"
+        }
+      ]
+    },
+    {
+      "code": "ng/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на секунда"
+        }
+      ]
+    },
+    {
+      "code": "ng/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanogramm/kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "нанограмм на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "nkat",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanokatal"
+        },
+        {
+          "language": "ru",
+          "value": "нанокатал"
+        }
+      ]
+    },
+    {
+      "code": "nL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanolitr"
+        },
+        {
+          "language": "ru",
+          "value": "нанолитр"
+        }
+      ]
+    },
+    {
+      "code": "nm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanometr"
+        },
+        {
+          "language": "ru",
+          "value": "нанометр"
+        }
+      ]
+    },
+    {
+      "code": "nm/s/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanometr/soniya/litr"
+        },
+        {
+          "language": "ru",
+          "value": "нанометр на секунда на литр"
+        }
+      ]
+    },
+    {
+      "code": "nmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль"
+        }
+      ]
+    },
+    {
+      "code": "nmol{BCE}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol suyak kollageni ekvivalenti"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль эквивалента костного коллагена"
+        }
+      ]
+    },
+    {
+      "code": "nmol{BCE}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol suyak kollageni ekvivalenti/litr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль эквивалента костного коллагена на литр"
+        }
+      ]
+    },
+    {
+      "code": "nmol{ATP}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol ATF"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль АТФ"
+        }
+      ]
+    },
+    {
+      "code": "nmol/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "nmol/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/kun"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на день"
+        }
+      ]
+    },
+    {
+      "code": "nmol/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/dL{GF}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/detsilitr glomerulyar filtratning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на децилитр клубочкового фильтрата"
+        }
+      ]
+    },
+    {
+      "code": "nmol/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на грамм"
+        }
+      ]
+    },
+    {
+      "code": "nmol/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/g{dry_wt}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/gramm quruq massaning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на грамм сухой массы"
+        }
+      ]
+    },
+    {
+      "code": "nmol/h/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/soat/litr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на час на литр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/h/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/soat/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на час на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "nmol/h/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/soat/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на час на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/L{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/litr eritrotsitlarning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на литр эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "nmol/L/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/litr/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на литр на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/m/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/metr/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на метр на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "nmol/umol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/mikromol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на микромоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mg{prot}/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/milligramm oqsilning/soat"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллиграмм белка на час"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mg/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/milligramm/soat"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллиграмм на час"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mL/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/millilitr/soat"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллилитр на час"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mL/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/millilitr/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллилитр в минуту"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/millimol"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллимоль"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min/mg{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa/milligramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту на миллиграмм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min/mg{protein}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa/milligramm oqsil"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту на миллиграмм белок"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "nmol/min/10*6{cells}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/daqiqa/million hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль в минуту на миллион клетки"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/mol"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на моль"
+        }
+      ]
+    },
+    {
+      "code": "nmol/mol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/mol kreatinin"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на моль креатинин"
+        }
+      ]
+    },
+    {
+      "code": "nmol/nmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/nanomol"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на наномоль"
+        }
+      ]
+    },
+    {
+      "code": "nmol/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на секунда"
+        }
+      ]
+    },
+    {
+      "code": "nmol/s/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanomol/soniya/litr"
+        },
+        {
+          "language": "ru",
+          "value": "наномоль на секунда на литр"
+        }
+      ]
+    },
+    {
+      "code": "ns",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nanosoniya"
+        },
+        {
+          "language": "ru",
+          "value": "наносекунда"
+        }
+      ]
+    },
+    {
+      "code": "N",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nyuton"
+        },
+        {
+          "language": "ru",
+          "value": "ньютон"
+        }
+      ]
+    },
+    {
+      "code": "N.cm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nyuton-santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "ньютон-сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "N.s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nyuton-soniya"
+        },
+        {
+          "language": "ru",
+          "value": "ньютон-секунда"
+        }
+      ]
+    },
+    {
+      "code": "{#}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "son"
+        },
+        {
+          "language": "ru",
+          "value": "число"
+        }
+      ]
+    },
+    {
+      "code": "{#}/a",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/yil"
+        },
+        {
+          "language": "ru",
+          "value": "number на год"
+        }
+      ]
+    },
+    {
+      "code": "{#}/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/kun"
+        },
+        {
+          "language": "ru",
+          "value": "number на день"
+        }
+      ]
+    },
+    {
+      "code": "{#}/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "number на грамм"
+        }
+      ]
+    },
+    {
+      "code": "{#}/[HPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/katta kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "number на поле зрения при большом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "{#}/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/litr"
+        },
+        {
+          "language": "ru",
+          "value": "number на литр"
+        }
+      ]
+    },
+    {
+      "code": "{#}/[LPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/kichik kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "number на поле зрения при малом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "{#}/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "number на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "{#}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "number на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "{#}/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "number в минуту"
+        }
+      ]
+    },
+    {
+      "code": "{#}/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "number/hafta"
+        },
+        {
+          "language": "ru",
+          "value": "number на неделя"
+        }
+      ]
+    },
+    {
+      "code": "Ohm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "om"
+        },
+        {
+          "language": "ru",
+          "value": "ом"
+        }
+      ]
+    },
+    {
+      "code": "Ohm.m",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "om-metr"
+        },
+        {
+          "language": "ru",
+          "value": "ом-метр"
+        }
+      ]
+    },
+    {
+      "code": "10*5",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "yuz ming"
+        },
+        {
+          "language": "ru",
+          "value": "сто тысяч"
+        }
+      ]
+    },
+    {
+      "code": "{OD_unit}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "optik zichlik birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица оптической плотности"
+        }
+      ]
+    },
+    {
+      "code": "osm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "osmol"
+        },
+        {
+          "language": "ru",
+          "value": "осмоль"
+        }
+      ]
+    },
+    {
+      "code": "osm/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "osmol/kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "осмоль на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "osm/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "osmol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "осмоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "[oz_av]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "untsiya (AQSh va Buyuk Britaniya)"
+        },
+        {
+          "language": "ru",
+          "value": "унция (США и Великобритания)"
+        }
+      ]
+    },
+    {
+      "code": "{Pan_Bio'U}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Panbio birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Panbio"
+        }
+      ]
+    },
+    {
+      "code": "[ppb]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliarddan bir qism"
+        },
+        {
+          "language": "ru",
+          "value": "часть на миллиард"
+        }
+      ]
+    },
+    {
+      "code": "[ppm]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliondan bir qism"
+        },
+        {
+          "language": "ru",
+          "value": "часть на миллион"
+        }
+      ]
+    },
+    {
+      "code": "[ppm]{v/v}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "milliondan bir qism, hajm/hajm"
+        },
+        {
+          "language": "ru",
+          "value": "часть на миллион, объем/объем"
+        }
+      ]
+    },
+    {
+      "code": "[ppth]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mingdan bir qism"
+        },
+        {
+          "language": "ru",
+          "value": "часть на тысячу"
+        }
+      ]
+    },
+    {
+      "code": "[pptr]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "trilliondan bir qism"
+        },
+        {
+          "language": "ru",
+          "value": "часть на триллион"
+        }
+      ]
+    },
+    {
+      "code": "Pa",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "paskal"
+        },
+        {
+          "language": "ru",
+          "value": "паскаль"
+        }
+      ]
+    },
+    {
+      "code": "/10*10",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 10 milliard"
+        },
+        {
+          "language": "ru",
+          "value": "на 10 миллиард"
+        }
+      ]
+    },
+    {
+      "code": "/10*4{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 10 ming eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "на 10 тысяч эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "/100",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 100"
+        },
+        {
+          "language": "ru",
+          "value": "на 100"
+        }
+      ]
+    },
+    {
+      "code": "/100{cells}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 100 hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "на 100 клетки"
+        }
+      ]
+    },
+    {
+      "code": "/100{neutrophils}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 100 neytrofillar"
+        },
+        {
+          "language": "ru",
+          "value": "на 100 нейтрофилы"
+        }
+      ]
+    },
+    {
+      "code": "/100{spermatozoa}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 100 spermatozoidlar"
+        },
+        {
+          "language": "ru",
+          "value": "на 100 сперматозоиды"
+        }
+      ]
+    },
+    {
+      "code": "/100{WBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per 100 leykotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "на 100 лейкоциты"
+        }
+      ]
+    },
+    {
+      "code": "/[arb'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per shartli birlik"
+        },
+        {
+          "language": "ru",
+          "value": "на условная единица"
+        }
+      ]
+    },
+    {
+      "code": "/10*9",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per milliard"
+        },
+        {
+          "language": "ru",
+          "value": "на миллиард"
+        }
+      ]
+    },
+    {
+      "code": "/cm[H2O]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per santimetr of suv ustuni"
+        },
+        {
+          "language": "ru",
+          "value": "на сантиметр of водный столб"
+        }
+      ]
+    },
+    {
+      "code": "/m3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kub metr"
+        },
+        {
+          "language": "ru",
+          "value": "на кубический метр"
+        }
+      ]
+    },
+    {
+      "code": "/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kun"
+        },
+        {
+          "language": "ru",
+          "value": "на день"
+        }
+      ]
+    },
+    {
+      "code": "/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "/{entity}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per obyekt"
+        },
+        {
+          "language": "ru",
+          "value": "на объект"
+        }
+      ]
+    },
+    {
+      "code": "/U",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per ferment birlik"
+        },
+        {
+          "language": "ru",
+          "value": "на фермент единица"
+        }
+      ]
+    },
+    {
+      "code": "/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм"
+        }
+      ]
+    },
+    {
+      "code": "/g{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "/g{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm gemoglobinning"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм гемоглобина"
+        }
+      ]
+    },
+    {
+      "code": "/g{tot_nit}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm umumiy azotning"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм общего азота"
+        }
+      ]
+    },
+    {
+      "code": "/g{tot_prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm umumiy oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм общего белка"
+        }
+      ]
+    },
+    {
+      "code": "/g{wet_tis}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per gramm nam to‘qimaning"
+        },
+        {
+          "language": "ru",
+          "value": "на грамм влажной ткани"
+        }
+      ]
+    },
+    {
+      "code": "/[HPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per katta kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "на поле зрения при большом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "/h",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per soat"
+        },
+        {
+          "language": "ru",
+          "value": "на час"
+        }
+      ]
+    },
+    {
+      "code": "/[IU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per international birlik"
+        },
+        {
+          "language": "ru",
+          "value": "на international единица"
+        }
+      ]
+    },
+    {
+      "code": "/kg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kilogramm"
+        },
+        {
+          "language": "ru",
+          "value": "на килограмм"
+        }
+      ]
+    },
+    {
+      "code": "/kg{body_wt}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kilogramm tana vaznining"
+        },
+        {
+          "language": "ru",
+          "value": "на килограмм массы тела"
+        }
+      ]
+    },
+    {
+      "code": "/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per litr"
+        },
+        {
+          "language": "ru",
+          "value": "на литр"
+        }
+      ]
+    },
+    {
+      "code": "/[LPF]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kichik kattalashtirishdagi ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "на поле зрения при малом увеличении"
+        }
+      ]
+    },
+    {
+      "code": "/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "/mm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per millimetr"
+        },
+        {
+          "language": "ru",
+          "value": "на миллиметр"
+        }
+      ]
+    },
+    {
+      "code": "/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "/10*6",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per million"
+        },
+        {
+          "language": "ru",
+          "value": "на миллион"
+        }
+      ]
+    },
+    {
+      "code": "/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "на минута"
+        }
+      ]
+    },
+    {
+      "code": "/mo",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per oy"
+        },
+        {
+          "language": "ru",
+          "value": "на месяц"
+        }
+      ]
+    },
+    {
+      "code": "/{OIF}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per immersion obyektivli ko‘rish maydoni"
+        },
+        {
+          "language": "ru",
+          "value": "на поле зрения с иммерсионным объективом"
+        }
+      ]
+    },
+    {
+      "code": "/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per soniya"
+        },
+        {
+          "language": "ru",
+          "value": "на секунда"
+        }
+      ]
+    },
+    {
+      "code": "/m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "на квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "/10*3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per ming"
+        },
+        {
+          "language": "ru",
+          "value": "на тысяча"
+        }
+      ]
+    },
+    {
+      "code": "/10*3{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per ming eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "на тысяча эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "/10*12",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per trillion"
+        },
+        {
+          "language": "ru",
+          "value": "на триллион"
+        }
+      ]
+    },
+    {
+      "code": "/10*12{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per trillion eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "на триллион эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "/(12.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per twelve soat"
+        },
+        {
+          "language": "ru",
+          "value": "на twelve час"
+        }
+      ]
+    },
+    {
+      "code": "/wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per hafta"
+        },
+        {
+          "language": "ru",
+          "value": "на неделя"
+        }
+      ]
+    },
+    {
+      "code": "/a",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "per yil"
+        },
+        {
+          "language": "ru",
+          "value": "на год"
+        }
+      ]
+    },
+    {
+      "code": "%",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz"
+        },
+        {
+          "language": "ru",
+          "value": "процент"
+        }
+      ]
+    },
+    {
+      "code": "%{loss_AChR}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: atsetilxolin retseptorlari yo‘qotilishi"
+        },
+        {
+          "language": "ru",
+          "value": "процент: ацетилхолиновых рецепторов, утрата"
+        }
+      ]
+    },
+    {
+      "code": "%{penetration}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: penetratsiya"
+        },
+        {
+          "language": "ru",
+          "value": "процент: проникновение"
+        }
+      ]
+    },
+    {
+      "code": "%{abnormal}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: anormal"
+        },
+        {
+          "language": "ru",
+          "value": "процент: аномальные"
+        }
+      ]
+    },
+    {
+      "code": "%{activity}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: faollik"
+        },
+        {
+          "language": "ru",
+          "value": "процент: активность"
+        }
+      ]
+    },
+    {
+      "code": "%{aggregation}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: agregatsiya"
+        },
+        {
+          "language": "ru",
+          "value": "процент: агрегация"
+        }
+      ]
+    },
+    {
+      "code": "%{at_60_min}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: 60 daqiqada"
+        },
+        {
+          "language": "ru",
+          "value": "процент: через 60 минут"
+        }
+      ]
+    },
+    {
+      "code": "%{basal_activity}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: bazal faollik"
+        },
+        {
+          "language": "ru",
+          "value": "процент: базальная активность"
+        }
+      ]
+    },
+    {
+      "code": "%{binding}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: bog‘lanish"
+        },
+        {
+          "language": "ru",
+          "value": "процент: связывание"
+        }
+      ]
+    },
+    {
+      "code": "%{blockade}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: blokada"
+        },
+        {
+          "language": "ru",
+          "value": "процент: блокада"
+        }
+      ]
+    },
+    {
+      "code": "%{blocked}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: bloklangan"
+        },
+        {
+          "language": "ru",
+          "value": "процент: заблокировано"
+        }
+      ]
+    },
+    {
+      "code": "%{bound}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: bog‘langan"
+        },
+        {
+          "language": "ru",
+          "value": "процент: связано"
+        }
+      ]
+    },
+    {
+      "code": "%{breakdown}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: parchalanish"
+        },
+        {
+          "language": "ru",
+          "value": "процент: распад"
+        }
+      ]
+    },
+    {
+      "code": "%{vol}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: hajm bo‘yicha"
+        },
+        {
+          "language": "ru",
+          "value": "процент: по объему"
+        }
+      ]
+    },
+    {
+      "code": "%{deficient}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: yetishmovchilik"
+        },
+        {
+          "language": "ru",
+          "value": "процент: дефицит"
+        }
+      ]
+    },
+    {
+      "code": "%{dose}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: doza"
+        },
+        {
+          "language": "ru",
+          "value": "процент: доза"
+        }
+      ]
+    },
+    {
+      "code": "%{excretion}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: ekskretsiya"
+        },
+        {
+          "language": "ru",
+          "value": "процент: экскреция"
+        }
+      ]
+    },
+    {
+      "code": "%{Hb}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: gemoglobin"
+        },
+        {
+          "language": "ru",
+          "value": "процент: гемоглобин"
+        }
+      ]
+    },
+    {
+      "code": "%{hemolysis}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: gemoliz"
+        },
+        {
+          "language": "ru",
+          "value": "процент: гемолиз"
+        }
+      ]
+    },
+    {
+      "code": "%{index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: indeks"
+        },
+        {
+          "language": "ru",
+          "value": "процент: индекс"
+        }
+      ]
+    },
+    {
+      "code": "%{inhibition}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: ingibitsiya"
+        },
+        {
+          "language": "ru",
+          "value": "процент: ингибирование"
+        }
+      ]
+    },
+    {
+      "code": "%{loss}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: yo‘qotish"
+        },
+        {
+          "language": "ru",
+          "value": "процент: потеря"
+        }
+      ]
+    },
+    {
+      "code": "%{lysis}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: lizis"
+        },
+        {
+          "language": "ru",
+          "value": "процент: лизис"
+        }
+      ]
+    },
+    {
+      "code": "%{normal}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: me’yor"
+        },
+        {
+          "language": "ru",
+          "value": "процент: норма"
+        }
+      ]
+    },
+    {
+      "code": "%{pooled_plasma}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: normal birlashtirilgan plazma"
+        },
+        {
+          "language": "ru",
+          "value": "процент: нормальная объединенная плазма"
+        }
+      ]
+    },
+    {
+      "code": "%{bacteria}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: bakteriyalar"
+        },
+        {
+          "language": "ru",
+          "value": "процент: бактерий"
+        }
+      ]
+    },
+    {
+      "code": "%{baseline}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: boshlang‘ich darajadan"
+        },
+        {
+          "language": "ru",
+          "value": "процент: от исходного уровня"
+        }
+      ]
+    },
+    {
+      "code": "%{cells}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "процент: клеток"
+        }
+      ]
+    },
+    {
+      "code": "%{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "процент: эритроцитов"
+        }
+      ]
+    },
+    {
+      "code": "%{WBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: leykotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "процент: лейкоцитов"
+        }
+      ]
+    },
+    {
+      "code": "%{positive}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: musbat"
+        },
+        {
+          "language": "ru",
+          "value": "процент: положительные"
+        }
+      ]
+    },
+    {
+      "code": "%{reactive}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: reaktiv"
+        },
+        {
+          "language": "ru",
+          "value": "процент: реактивные"
+        }
+      ]
+    },
+    {
+      "code": "%{recovery}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: tiklanish"
+        },
+        {
+          "language": "ru",
+          "value": "процент: восстановление"
+        }
+      ]
+    },
+    {
+      "code": "%{reference}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: referens qiymat"
+        },
+        {
+          "language": "ru",
+          "value": "процент: референсное значение"
+        }
+      ]
+    },
+    {
+      "code": "%{residual}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: qoldiq"
+        },
+        {
+          "language": "ru",
+          "value": "процент: остаточный"
+        }
+      ]
+    },
+    {
+      "code": "%{response}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: javob"
+        },
+        {
+          "language": "ru",
+          "value": "процент: ответ"
+        }
+      ]
+    },
+    {
+      "code": "%{saturation}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: to‘yinganlik"
+        },
+        {
+          "language": "ru",
+          "value": "процент: насыщение"
+        }
+      ]
+    },
+    {
+      "code": "%{total}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: umumiy"
+        },
+        {
+          "language": "ru",
+          "value": "процент: общее"
+        }
+      ]
+    },
+    {
+      "code": "%{uptake}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: yutilish"
+        },
+        {
+          "language": "ru",
+          "value": "процент: поглощение"
+        }
+      ]
+    },
+    {
+      "code": "%{viable}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "foiz: yashovchan"
+        },
+        {
+          "language": "ru",
+          "value": "процент: жизнеспособные"
+        }
+      ]
+    },
+    {
+      "code": "{percentile}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "persentil"
+        },
+        {
+          "language": "ru",
+          "value": "процентиль"
+        }
+      ]
+    },
+    {
+      "code": "[pH]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pH"
+        },
+        {
+          "language": "ru",
+          "value": "pH"
+        }
+      ]
+    },
+    {
+      "code": "{phenotype}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "fenotip"
+        },
+        {
+          "language": "ru",
+          "value": "фенотип"
+        }
+      ]
+    },
+    {
+      "code": "pA",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikoamper"
+        },
+        {
+          "language": "ru",
+          "value": "пикоампер"
+        }
+      ]
+    },
+    {
+      "code": "pg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм"
+        }
+      ]
+    },
+    {
+      "code": "pg/{cell}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/hujayra"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на клетка"
+        }
+      ]
+    },
+    {
+      "code": "pg/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "pg/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/litr"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на литр"
+        }
+      ]
+    },
+    {
+      "code": "pg/mg",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/milligramm"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на миллиграмм"
+        }
+      ]
+    },
+    {
+      "code": "pg/mg{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/milligramm kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на миллиграмм креатинина"
+        }
+      ]
+    },
+    {
+      "code": "pg/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "pg/mL{sLT}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/millilitr sulfidoleukotrienes"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на миллилитр sulfidoleukotrienes"
+        }
+      ]
+    },
+    {
+      "code": "pg/mm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/millimetr"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на миллиметр"
+        }
+      ]
+    },
+    {
+      "code": "pg/{RBC}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikogramm/eritrotsit"
+        },
+        {
+          "language": "ru",
+          "value": "пикограмм на эритроцит"
+        }
+      ]
+    },
+    {
+      "code": "pkat",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikokatal"
+        },
+        {
+          "language": "ru",
+          "value": "пикокатал"
+        }
+      ]
+    },
+    {
+      "code": "pL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikolitr"
+        },
+        {
+          "language": "ru",
+          "value": "пиколитр"
+        }
+      ]
+    },
+    {
+      "code": "pm",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikometr"
+        },
+        {
+          "language": "ru",
+          "value": "пикометр"
+        }
+      ]
+    },
+    {
+      "code": "pmol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль"
+        }
+      ]
+    },
+    {
+      "code": "pmol/(24.h)",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/24 soat"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на 24 час"
+        }
+      ]
+    },
+    {
+      "code": "pmol/d",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/kun"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на день"
+        }
+      ]
+    },
+    {
+      "code": "pmol/dL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/detsilitr"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на децилитр"
+        }
+      ]
+    },
+    {
+      "code": "pmol/g",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/gramm"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на грамм"
+        }
+      ]
+    },
+    {
+      "code": "pmol/h/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/soat/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на час на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "pmol/H/mg{protein}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/soat/milligramm oqsil"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на час на миллиграмм белок"
+        }
+      ]
+    },
+    {
+      "code": "pmol/h/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/soat/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на час на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "pmol/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/litr"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на литр"
+        }
+      ]
+    },
+    {
+      "code": "pmol/umol",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/mikromol"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на микромоль"
+        }
+      ]
+    },
+    {
+      "code": "pmol/umol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/mikromol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на микромоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "pmol/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "pmol/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "pmol/mmol{creat}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/millimol kreatininning"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на миллимоль креатинина"
+        }
+      ]
+    },
+    {
+      "code": "pmol/min",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/daqiqa"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль в минуту"
+        }
+      ]
+    },
+    {
+      "code": "pmol/min/mg{prot}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/daqiqa/milligramm oqsilning"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль в минуту на миллиграмм белка"
+        }
+      ]
+    },
+    {
+      "code": "pmol/{RBC}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikomol/eritrotsit"
+        },
+        {
+          "language": "ru",
+          "value": "пикомоль на эритроцит"
+        }
+      ]
+    },
+    {
+      "code": "ps",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikosoniya"
+        },
+        {
+          "language": "ru",
+          "value": "пикосекунда"
+        }
+      ]
+    },
+    {
+      "code": "pT",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pikotesla"
+        },
+        {
+          "language": "ru",
+          "value": "пикотесла"
+        }
+      ]
+    },
+    {
+      "code": "[pt_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pinta (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "пинта (США)"
+        }
+      ]
+    },
+    {
+      "code": "[lb_av]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "funt (AQSh va Buyuk Britaniya)"
+        },
+        {
+          "language": "ru",
+          "value": "фунт (США и Великобритания)"
+        }
+      ]
+    },
+    {
+      "code": "[psi]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "pound/kvadrat dyuym"
+        },
+        {
+          "language": "ru",
+          "value": "pound на квадратный дюйм"
+        }
+      ]
+    },
+    {
+      "code": "[qt_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvarta (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "кварта (США)"
+        }
+      ]
+    },
+    {
+      "code": "{ratio}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nisbat"
+        },
+        {
+          "language": "ru",
+          "value": "отношение"
+        }
+      ]
+    },
+    {
+      "code": "{RBC}/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrolitrga eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "эритроцитов на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "%{relative}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nisbiy foiz"
+        },
+        {
+          "language": "ru",
+          "value": "относительный процент"
+        }
+      ]
+    },
+    {
+      "code": "{rel_saturation}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "nisbiy to‘yinganlik"
+        },
+        {
+          "language": "ru",
+          "value": "относительное насыщение"
+        }
+      ]
+    },
+    {
+      "code": "{risk}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "xavf"
+        },
+        {
+          "language": "ru",
+          "value": "риск"
+        }
+      ]
+    },
+    {
+      "code": "{Rubella_virus}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "qizilcha virusi"
+        },
+        {
+          "language": "ru",
+          "value": "вирус краснухи"
+        }
+      ]
+    },
+    {
+      "code": "{saturation}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "to‘yinganlik"
+        },
+        {
+          "language": "ru",
+          "value": "насыщение"
+        }
+      ]
+    },
+    {
+      "code": "{score}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ball"
+        },
+        {
+          "language": "ru",
+          "value": "балл"
+        }
+      ]
+    },
+    {
+      "code": "s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "soniya"
+        },
+        {
+          "language": "ru",
+          "value": "секунда"
+        }
+      ]
+    },
+    {
+      "code": "s/{control}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "soniya/nazorat"
+        },
+        {
+          "language": "ru",
+          "value": "секунда на контроль"
+        }
+      ]
+    },
+    {
+      "code": "{shift}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "smena"
+        },
+        {
+          "language": "ru",
+          "value": "смена"
+        }
+      ]
+    },
+    {
+      "code": "S",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "simens"
+        },
+        {
+          "language": "ru",
+          "value": "сименс"
+        }
+      ]
+    },
+    {
+      "code": "Sv",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "zivert"
+        },
+        {
+          "language": "ru",
+          "value": "зиверт"
+        }
+      ]
+    },
+    {
+      "code": "{s_co_ratio}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "signalning chegara qiymatiga nisbati"
+        },
+        {
+          "language": "ru",
+          "value": "отношение сигнала к пороговому значению"
+        }
+      ]
+    },
+    {
+      "code": "{spermatozoa}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "millilitrga spermatozoidlar"
+        },
+        {
+          "language": "ru",
+          "value": "сперматозоидов на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "cm2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat santimetr"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный сантиметр"
+        }
+      ]
+    },
+    {
+      "code": "cm2/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat santimetr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный сантиметр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "dm2/s2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat detsimetr/kvadrat soniya"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный дециметр на квадратная секунда"
+        }
+      ]
+    },
+    {
+      "code": "[sft_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat fut (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный фут (международный)"
+        }
+      ]
+    },
+    {
+      "code": "[sin_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat dyuym (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный дюйм (международный)"
+        }
+      ]
+    },
+    {
+      "code": "m2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat metr"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный метр"
+        }
+      ]
+    },
+    {
+      "code": "m2/s",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat metr/soniya"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный метр на секунда"
+        }
+      ]
+    },
+    {
+      "code": "mm2",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat millimetr"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный миллиметр"
+        }
+      ]
+    },
+    {
+      "code": "[syd_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "kvadrat yard (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "квадратный ярд (международный)"
+        }
+      ]
+    },
+    {
+      "code": "{STDV}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "standart og‘ish"
+        },
+        {
+          "language": "ru",
+          "value": "стандартное отклонение"
+        }
+      ]
+    },
+    {
+      "code": "{Tscore}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "T-ko‘rsatkich"
+        },
+        {
+          "language": "ru",
+          "value": "T-показатель"
+        }
+      ]
+    },
+    {
+      "code": "[tbs_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "osh qoshiq (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "столовая ложка (США)"
+        }
+      ]
+    },
+    {
+      "code": "[tsp_us]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "choy qoshiq (AQSh)"
+        },
+        {
+          "language": "ru",
+          "value": "чайная ложка (США)"
+        }
+      ]
+    },
+    {
+      "code": "T",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "tesla"
+        },
+        {
+          "language": "ru",
+          "value": "тесла"
+        }
+      ]
+    },
+    {
+      "code": "10*3",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча"
+        }
+      ]
+    },
+    {
+      "code": "10*3{copies}/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming nusxalar/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча копии на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "10*3/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming/litr"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча на литр"
+        }
+      ]
+    },
+    {
+      "code": "10*3/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming/mikrolitr"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "10*3/mL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming/millilitr"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча на миллилитр"
+        }
+      ]
+    },
+    {
+      "code": "10*3{RBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "ming eritrotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "тысяча эритроциты"
+        }
+      ]
+    },
+    {
+      "code": "{TSI_index}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "tiroidni stimulyatsiya qiluvchi immunoglobulin indeksi"
+        },
+        {
+          "language": "ru",
+          "value": "индекс тиреостимулирующего иммуноглобулина"
+        }
+      ]
+    },
+    {
+      "code": "{TmStp}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "vaqt belgisi"
+        },
+        {
+          "language": "ru",
+          "value": "метка времени"
+        }
+      ]
+    },
+    {
+      "code": "{titer}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "titr"
+        },
+        {
+          "language": "ru",
+          "value": "титр"
+        }
+      ]
+    },
+    {
+      "code": "[todd'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Todd birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица Тодда"
+        }
+      ]
+    },
+    {
+      "code": "10*12/L",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "trillion/litr"
+        },
+        {
+          "language": "ru",
+          "value": "триллион на литр"
+        }
+      ]
+    },
+    {
+      "code": "[oz_tr]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "troy untsiyasi"
+        },
+        {
+          "language": "ru",
+          "value": "тройская унция"
+        }
+      ]
+    },
+    {
+      "code": "[tb'U]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "tuberkulin birligi"
+        },
+        {
+          "language": "ru",
+          "value": "туберкулиновая единица"
+        }
+      ]
+    },
+    {
+      "code": "V",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "volt"
+        },
+        {
+          "language": "ru",
+          "value": "вольт"
+        }
+      ]
+    },
+    {
+      "code": "Wb",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "veber"
+        },
+        {
+          "language": "ru",
+          "value": "вебер"
+        }
+      ]
+    },
+    {
+      "code": "wk",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "hafta"
+        },
+        {
+          "language": "ru",
+          "value": "неделя"
+        }
+      ]
+    },
+    {
+      "code": "{WBCs}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "leykotsitlar"
+        },
+        {
+          "language": "ru",
+          "value": "лейкоциты"
+        }
+      ]
+    },
+    {
+      "code": "[yd_i]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "yard (xalqaro)"
+        },
+        {
+          "language": "ru",
+          "value": "ярд (международный)"
+        }
+      ]
+    },
+    {
+      "code": "a",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "yil"
+        },
+        {
+          "language": "ru",
+          "value": "год"
+        }
+      ]
+    },
+    {
+      "code": "{yyyy}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "yil"
+        },
+        {
+          "language": "ru",
+          "value": "год"
+        }
+      ]
+    },
+    {
+      "code": "{Zscore}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "Z-ball"
+        },
+        {
+          "language": "ru",
+          "value": "Z-оценка"
+        }
+      ]
+    },
+    {
+      "code": "[ELU]",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "IFA birligi"
+        },
+        {
+          "language": "ru",
+          "value": "единица ИФА"
+        }
+      ]
+    },
+    {
+      "code": "mmol/{sperm}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "sperma namunasiga millimol"
+        },
+        {
+          "language": "ru",
+          "value": "миллимоль на образец спермы"
+        }
+      ]
+    },
+    {
+      "code": "{S/CO}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "signalning chegara qiymatiga nisbati"
+        },
+        {
+          "language": "ru",
+          "value": "отношение сигнала к пороговому значению"
+        }
+      ]
+    },
+    {
+      "code": "{cell}/uL",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "mikrolitrga hujayralar"
+        },
+        {
+          "language": "ru",
+          "value": "клеток на микролитр"
+        }
+      ]
+    },
+    {
+      "code": "{copies}/10*5{cell}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "100 000 ta hujayraga nusxalar"
+        },
+        {
+          "language": "ru",
+          "value": "копий на 100 000 клеток"
+        }
+      ]
+    },
+    {
+      "code": "{log10}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "10 asosli logarifm"
+        },
+        {
+          "language": "ru",
+          "value": "десятичный логарифм"
+        }
+      ]
+    },
+    {
+      "code": "{per_HPF}",
+      "designation": [
+        {
+          "language": "uz",
+          "value": "katta kattalashtirishdagi ko‘rish maydoniga"
+        },
+        {
+          "language": "ru",
+          "value": "на поле зрения при большом увеличении"
+        }
+      ]
+    }
+  ],
+  "supplements": "http://unitsofmeasure.org",
+  "version": "2.2.0",
+  "language": "en",
+  "experimental": true
+}


### PR DESCRIPTION
Follow-up to #256.

#### Shifted translations

From `[oz_tr]` through `{Zscore}` each code carried the *previous* code's translation. `V` (volt) rendered as "туберкулиновая единица", `wk` (week) as "вебер", `[tb'U]` (tuberculin unit) as "тройская унция". `10*12/L` was left as an untranslated placeholder and `{Zscore}` duplicated "год". Realigned, and `{Zscore}` given a real translation.

#### Duplicate concepts

`nmol/mmol{creat}` and `nmol/mg{prot}` were each defined twice with conflicting text. The removed copies carried LOINC test context that isn't in the unit ("эквивалента костного коллагена", "1/2 цистина"); the generic-correct definitions later in the file are kept. 852 concepts, all unique.

#### Version

`1.5.0` -> `2.2.0`. tx.fhir.org reports UCUM `2.2`, and modelling-guidelines section 5.1 requires a supplement's version to reflect the release it supplements, SemVer-encoded.

#### Pre-generation

854 concepts is well over the 100-code threshold in section 5.1, so the JSON moves to `input/vocabulary/` and the FSH to `input/manual-fsh/`. `Canonical(UCUMUnitsSupplementCS)` in `UCUMUnitsSupplementVS.fsh` still resolves - SUSHI loads `input/vocabulary/` as a predefined resource, same as `ATCClassificationCS` and `LabUnitsCS` already do.