### PR TITLE
Stop suppressing broken links, and remove the dead patient-instructions menu entry

### DIFF
--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -21,9 +21,6 @@ The ImplementationGuide uses package hl7.fhir.uv.sdc#3.0.0 released on 2022-03-0
 Resource has a language (uz), and the XHTML has a lang (en), but they differ
 Resource has a language (ru), and the XHTML has a lang (en), but they differ
 
-# Publisher bug with new .ai.html pages, can be ignored
-The link%
-
 # Publisher issue where codesystems and valuesets can no longer share the same name
 There are multiple resources with the same title%
 

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -160,7 +160,6 @@ menu:
     Vital signs: vital-signs.html
   Workflows: workflows.html
   Forms: forms.html
-  Patient instructions: patient-instructions.html
   API access: api-access.html
   Artifacts: artifacts.html
   Components: components.html


### PR DESCRIPTION
The `The link%` rule in `ignoreWarnings.txt` was written for an `.ai.html` publisher bug that no longer exists in publisher 2.3.0, so it was only hiding real breakage - 7,630 broken links, 7,467 of them from a `patient-instructions.html` menu entry added in #252 for a page that was never created.

Removing both takes the QA report from 7,630 broken links to 163. `errs`/`warnings` stay at 0 throughout, because the publisher files broken links under `hints` and CI only gates on the other two - so broken links have never actually been enforced here.