### PR TITLE
Add interactive cross-component resource architecture diagram to Components page

### DIFF
--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -392,8 +392,6 @@
     applyTransform();
   }, { passive: false });
 
-  var resetBtn = document.getElementById('arch-reset');
-  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; setActive(null); fitView(); });
   window.addEventListener('resize', fitView);
   fitView();
 })();

--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -311,6 +311,7 @@
 
   var canvas = document.getElementById('arch-canvas');
   var tx = 0, ty = 0, scale = 1, dragging = false, dragMoved = false, lastX = 0, lastY = 0;
+  var userAdjusted = false;
 
   function applyTransform() { viewport.setAttribute('transform', 'translate(' + tx + ',' + ty + ') scale(' + scale + ')'); }
 
@@ -332,7 +333,7 @@
   canvas.addEventListener('pointermove', function (ev) {
     if (!dragging) return;
     var dx = ev.clientX - lastX, dy = ev.clientY - lastY;
-    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) dragMoved = true;
+    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) { dragMoved = true; userAdjusted = true; }
     tx += dx; ty += dy; lastX = ev.clientX; lastY = ev.clientY;
     applyTransform();
   });
@@ -349,11 +350,22 @@
     var newScale = Math.max(0.25, Math.min(2.5, scale * factor));
     var contentX = (mx - tx) / scale, contentY = (my - ty) / scale;
     tx = mx - contentX * newScale; ty = my - contentY * newScale; scale = newScale;
+    userAdjusted = true;
     applyTransform();
   }, { passive: false });
 
   var resetBtn = document.getElementById('arch-reset');
-  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; setActive(null); fitView(); });
-  window.addEventListener('resize', fitView);
+  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; userAdjusted = false; setActive(null); fitView(); });
+
+  // The page's own layout (e.g. the floating table of contents) can still be
+  // settling after this script runs, changing the canvas's width out from
+  // under the initial fitView(). Re-fit on any size change until the reader
+  // has taken control (panned/zoomed), rather than relying on 'resize' alone.
+  function refitIfUntouched() { if (!userAdjusted) fitView(); }
+  if (window.ResizeObserver) {
+    new ResizeObserver(refitIfUntouched).observe(canvas);
+  } else {
+    window.addEventListener('resize', refitIfUntouched);
+  }
   fitView();
 })();

--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -1,0 +1,359 @@
+/*
+ * Interactive resource-flow diagram for the Components page: which FHIR
+ * resources each component owns, and which of those resources plausibly
+ * flow to another component. Solid edges are relationships stated in the
+ * components' Technical Projects; dashed edges are inferred from shared
+ * resource types.
+ *
+ * This file lives in input/images/ (copied verbatim to output/ and to every
+ * language directory) and is loaded from the components page. It must stay
+ * an external file: pagecontent is processed by Jekyll, which would
+ * interpret {{ and {% inside inline script.
+ *
+ * Data mirrors input/images-source/resource-relationships.plantuml and the
+ * component-to-component relationships documented in each component's
+ * Technical Project (see components.md).
+ */
+(function () {
+  var svgNS = 'http://www.w3.org/2000/svg';
+  var MONO_FONT = "ui-monospace, 'SFMono-Regular', Menlo, Consolas, 'Liberation Mono', monospace";
+
+  function el(tag, attrs) {
+    var e = document.createElementNS(svgNS, tag);
+    for (var k in attrs) e.setAttribute(k, attrs[k]);
+    return e;
+  }
+
+  var TIERS = [
+    ["MDM", "MSM"],
+    ["CHR", "PHJM"],
+    ["LAB", "REFERRALS", "REIMB", "SCREEN", "VACC"]
+  ];
+
+  var COMPONENTS = {
+    MDM: { short: "MDM", label: "Master Data Management (MDM)", resources: [] },
+    MSM: { short: "MSM", label: "Metadata and Security Management (MSM)", resources: [
+      { name: "StructureDefinition" }, { name: "ValueSet" }, { name: "CodeSystem" }, { name: "CapabilityStatement" },
+      { name: "Provenance", profiled: true }, { name: "AuditEvent", profiled: true }, { name: "Consent", profiled: true }
+    ]},
+    CHR: { short: "CHR", label: "Clinical Health Records (CHR)", resources: [
+      { name: "Patient", profiled: true }, { name: "EpisodeOfCare", profiled: true }, { name: "Condition", profiled: true },
+      { name: "Observation", profiled: true }, { name: "Procedure", profiled: true }, { name: "AllergyIntolerance", profiled: true },
+      { name: "MedicationRequest" }
+    ]},
+    PHJM: { short: "PHJM", label: "Patient health journey management (PHJM)", resources: [
+      { name: "EpisodeOfCare", profiled: true }, { name: "Encounter", profiled: true }, { name: "Condition", profiled: true },
+      { name: "Observation", profiled: true }, { name: "CarePlan" }, { name: "Questionnaire", profiled: true },
+      { name: "QuestionnaireResponse", profiled: true }
+    ]},
+    LAB: { short: "Laboratory", label: "Laboratory", resources: [
+      { name: "Observation", profiled: true }, { name: "Specimen", profiled: true },
+      { name: "DiagnosticReport", profiled: true }, { name: "ServiceRequest", profiled: true }
+    ]},
+    REFERRALS: { short: "Referrals", label: "Referrals", resources: [] },
+    REIMB: { short: "Reimbursement", label: "Reimbursement", resources: [
+      { name: "Claim", profiled: true }, { name: "ClaimResponse", profiled: true }, { name: "Encounter", profiled: true },
+      { name: "Procedure", profiled: true }, { name: "MedicationDispense", profiled: true }, { name: "Condition", profiled: true },
+      { name: "Observation", profiled: true }, { name: "CarePlan" }, { name: "Composition", profiled: true }
+    ]},
+    SCREEN: { short: "Screening Schedules", label: "Screening Schedules Management", resources: [
+      { name: "Questionnaire", profiled: true }
+    ]},
+    VACC: { short: "Vaccination Mgmt", label: "Vaccination Management", resources: [] }
+  };
+
+  var EDGES = [
+    { from: "CHR", to: "MDM", kind: "documented", label: "full compatibility" },
+    { from: "CHR", to: "MSM", kind: "documented", label: "full compatibility" },
+    { from: "MDM", to: "MSM", kind: "documented", label: "metadata, security, clinical info" },
+    { from: "PHJM", to: "CHR", kind: "documented", label: "integration" },
+    { from: "PHJM", to: "MSM", kind: "documented", label: "integration" },
+    { from: "PHJM", to: "MDM", kind: "documented", label: "integration" },
+    { from: "CHR.EpisodeOfCare", to: "PHJM.EpisodeOfCare", kind: "inferred", label: "inferred" },
+    { from: "CHR.Condition", to: "PHJM.Condition", kind: "inferred", label: "inferred" },
+    { from: "CHR.Observation", to: "PHJM.Observation", kind: "inferred", label: "inferred" },
+    { from: "LAB.Observation", to: "CHR.Observation", kind: "inferred", label: "lab results — inferred" },
+    { from: "REFERRALS", to: "LAB.ServiceRequest", kind: "inferred", label: "referral request — inferred" },
+    { from: "CHR.Procedure", to: "REIMB.Procedure", kind: "inferred", label: "inferred" },
+    { from: "CHR.Condition", to: "REIMB.Condition", kind: "inferred", label: "inferred" },
+    { from: "CHR.Observation", to: "REIMB.Observation", kind: "inferred", label: "inferred" },
+    { from: "PHJM.Encounter", to: "REIMB.Encounter", kind: "inferred", label: "inferred" },
+    { from: "PHJM.CarePlan", to: "REIMB.CarePlan", kind: "inferred", label: "inferred" },
+    { from: "PHJM.Questionnaire", to: "SCREEN.Questionnaire", kind: "inferred", label: "inferred" }
+  ];
+
+  var BOX_W = 220, PILL_H = 26, PILL_GAP = 6, PILL_INSET = 10,
+      TITLE_H = 30, PAD_TOP = 8, PAD_BOTTOM = 10, EMPTY_H = 46,
+      TIER_GAP = 64, BOX_GAP = 26;
+
+  var boxes = {}, pills = {};
+  var curY = 30, minLeft = Infinity, maxRight = -Infinity;
+
+  TIERS.forEach(function (tierIds) {
+    var heights = tierIds.map(function (id) {
+      var res = COMPONENTS[id].resources;
+      if (!res.length) return EMPTY_H;
+      return TITLE_H + PAD_TOP + res.length * PILL_H + (res.length - 1) * PILL_GAP + PAD_BOTTOM;
+    });
+    var rowH = Math.max.apply(null, heights);
+    var rowW = tierIds.length * BOX_W + (tierIds.length - 1) * BOX_GAP;
+    var curX = -rowW / 2;
+    tierIds.forEach(function (id, i) {
+      var h = heights[i];
+      boxes[id] = { x: curX, y: curY, w: BOX_W, h: h, id: id };
+      var res = COMPONENTS[id].resources;
+      res.forEach(function (r, ri) {
+        var py = curY + TITLE_H + PAD_TOP + ri * (PILL_H + PILL_GAP);
+        pills[id + "::" + r.name] = { x: curX + PILL_INSET, y: py, w: BOX_W - 2 * PILL_INSET, h: PILL_H, name: r.name, profiled: !!r.profiled, compId: id };
+      });
+      if (curX < minLeft) minLeft = curX;
+      if (curX + BOX_W > maxRight) maxRight = curX + BOX_W;
+      curX += BOX_W + BOX_GAP;
+    });
+    curY += rowH + TIER_GAP;
+  });
+  var totalH = curY - TIER_GAP + 30;
+  var totalW = maxRight - minLeft;
+
+  function resolveEndpoint(str) {
+    var parts = str.split(".");
+    if (parts.length === 2) return { kind: "pill", id: parts[0] + "::" + parts[1], compId: parts[0] };
+    return { kind: "box", id: parts[0], compId: parts[0] };
+  }
+  function rectOf(r) { return r.kind === "pill" ? pills[r.id] : boxes[r.id]; }
+
+  EDGES.forEach(function (e) { e.fromR = resolveEndpoint(e.from); e.toR = resolveEndpoint(e.to); });
+
+  function boundaryPoint(rect, other) {
+    var acx = rect.x + rect.w / 2, acy = rect.y + rect.h / 2;
+    var bcx = other.x + other.w / 2, bcy = other.y + other.h / 2;
+    var dx = bcx - acx, dy = bcy - acy;
+    if (Math.abs(dx) > Math.abs(dy)) return { x: dx > 0 ? rect.x + rect.w : rect.x, y: acy };
+    return { x: acx, y: dy > 0 ? rect.y + rect.h : rect.y };
+  }
+
+  function curvePath(p1, p2) {
+    var dx = p2.x - p1.x, dy = p2.y - p1.y;
+    if (Math.abs(dx) > Math.abs(dy)) {
+      var c = Math.max(40, Math.abs(dx) * 0.5), sx = dx >= 0 ? 1 : -1;
+      return "M" + p1.x + "," + p1.y + " C" + (p1.x + sx * c) + "," + p1.y + " " + (p2.x - sx * c) + "," + p2.y + " " + p2.x + "," + p2.y;
+    }
+    var c2 = Math.max(40, Math.abs(dy) * 0.5), sy = dy >= 0 ? 1 : -1;
+    return "M" + p1.x + "," + p1.y + " C" + p1.x + "," + (p1.y + sy * c2) + " " + p2.x + "," + (p2.y - sy * c2) + " " + p2.x + "," + p2.y;
+  }
+
+  var svg = document.getElementById('arch-svg');
+  if (!svg) return;
+
+  var defs = el('defs', {});
+  var arrowInferred = el('marker', { id: 'arch-arrow-inferred', viewBox: '0 0 10 10', refX: '8', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto' });
+  arrowInferred.appendChild(el('path', { d: 'M0,0 L10,5 L0,10 z' }));
+  defs.appendChild(arrowInferred);
+  svg.appendChild(defs);
+
+  var viewport = el('g', { id: 'arch-viewport' });
+  svg.appendChild(viewport);
+  var edgeLayer = el('g', {});
+  var nodeLayer = el('g', {});
+  viewport.appendChild(edgeLayer);
+  viewport.appendChild(nodeLayer);
+
+  var edgeEls = [];
+  EDGES.forEach(function (e) {
+    var p1 = boundaryPoint(rectOf(e.fromR), rectOf(e.toR));
+    var p2 = boundaryPoint(rectOf(e.toR), rectOf(e.fromR));
+    var path = el('path', { d: curvePath(p1, p2), class: 'arch-edge', fill: 'none' });
+    path.style.stroke = e.kind === 'documented' ? 'var(--blueprint)' : 'var(--pencil)';
+    path.setAttribute('stroke-width', e.kind === 'documented' ? '2' : '1.5');
+    if (e.kind === 'inferred') {
+      path.setAttribute('stroke-dasharray', '5,4');
+      path.setAttribute('marker-end', 'url(#arch-arrow-inferred)');
+    }
+    edgeLayer.appendChild(path);
+    edgeEls.push({ el: path, edge: e });
+  });
+
+  var nodeEls = {};
+  function makeNode(id, rect, isBox, data) {
+    var g = el('g', { class: 'arch-node', 'data-id': id, tabindex: '0', role: 'button' });
+    var r = el('rect', { x: rect.x, y: rect.y, width: rect.w, height: rect.h });
+    if (isBox) {
+      r.style.fill = 'var(--paper-raised)';
+      r.style.stroke = 'var(--line)';
+      r.setAttribute('stroke-width', '1.5');
+    } else {
+      r.style.fill = data.profiled ? 'var(--blueprint-soft)' : 'var(--pencil-soft)';
+      r.style.stroke = 'none';
+    }
+    g.appendChild(r);
+
+    var label = isBox ? COMPONENTS[id].short : data.name;
+    var text = el('text', {
+      x: isBox ? rect.x + 10 : rect.x + rect.w / 2,
+      y: isBox ? rect.y + 19 : rect.y + rect.h / 2 + 4,
+      'text-anchor': isBox ? 'start' : 'middle',
+      'font-family': MONO_FONT,
+      'font-size': isBox ? '12' : '10',
+      'font-weight': isBox ? '600' : '500'
+    });
+    text.style.fill = isBox ? 'var(--ink)' : (data.profiled ? 'var(--blueprint)' : 'var(--ink-soft)');
+    text.textContent = label;
+    g.appendChild(text);
+
+    g.setAttribute('aria-label', isBox ? COMPONENTS[id].label : (data.name + ' — ' + COMPONENTS[data.compId].label));
+    nodeLayer.appendChild(g);
+    nodeEls[id] = { el: g };
+  }
+
+  Object.keys(boxes).forEach(function (id) { makeNode(id, boxes[id], true, null); });
+  Object.keys(pills).forEach(function (id) { makeNode(id, pills[id], false, pills[id]); });
+
+  var pinnedId = null;
+  var infoBody = document.getElementById('arch-info-body');
+
+  var statEls = {
+    components: document.getElementById('arch-stat-components'),
+    resources: document.getElementById('arch-stat-resources'),
+    documented: document.getElementById('arch-stat-documented'),
+    inferred: document.getElementById('arch-stat-inferred')
+  };
+  if (statEls.components) statEls.components.textContent = Object.keys(boxes).length;
+  if (statEls.resources) statEls.resources.textContent = Object.keys(pills).length;
+  if (statEls.documented) statEls.documented.textContent = EDGES.filter(function (e) { return e.kind === 'documented'; }).length;
+  if (statEls.inferred) statEls.inferred.textContent = EDGES.filter(function (e) { return e.kind === 'inferred'; }).length;
+
+  var defaultInfoHTML = infoBody.innerHTML;
+
+  function edgesFor(id, isBox) {
+    return edgeEls.filter(function (rec) {
+      var e = rec.edge;
+      return isBox ? (e.fromR.compId === id || e.toR.compId === id) : (e.fromR.id === id || e.toR.id === id);
+    });
+  }
+
+  function otherInfo(edge, id, isBox) {
+    var fromMatches = isBox ? edge.fromR.compId === id : edge.fromR.id === id;
+    var other = fromMatches ? edge.toR : edge.fromR;
+    var dir = edge.kind === 'documented' ? '↔' : (fromMatches ? '→' : '←');
+    var label = other.kind === 'pill' ? (pills[other.id].name + ' · ' + COMPONENTS[other.compId].short) : COMPONENTS[other.compId].label;
+    return { dir: dir, label: label };
+  }
+
+  function setActive(id) {
+    var isBox = id ? !!boxes[id] : false;
+    var related = id ? edgesFor(id, isBox) : [];
+    var activeNodeIds = {};
+    if (id) activeNodeIds[id] = true;
+    related.forEach(function (rec) { activeNodeIds[rec.edge.fromR.id] = true; activeNodeIds[rec.edge.toR.id] = true; });
+
+    edgeEls.forEach(function (rec) {
+      var isActive = !id || related.indexOf(rec) !== -1;
+      rec.el.classList.toggle('dim', !!id && !isActive);
+    });
+    Object.keys(nodeEls).forEach(function (nid) {
+      var isActive = !id || nid === id || activeNodeIds[nid];
+      nodeEls[nid].el.classList.toggle('dim', !!id && !isActive);
+      nodeEls[nid].el.classList.toggle('active', !!id && nid === id);
+    });
+
+    if (!id) { infoBody.innerHTML = defaultInfoHTML; return; }
+
+    var isBoxNode = !!boxes[id];
+    var titleText = isBoxNode ? COMPONENTS[id].short : pills[id].name;
+    var subText = isBoxNode ? COMPONENTS[id].label : COMPONENTS[pills[id].compId].label;
+    var wrap = document.createElement('div');
+    var t = document.createElement('p'); t.className = 'arch-info-title'; t.textContent = titleText;
+    var s = document.createElement('p'); s.className = 'arch-info-sub'; s.textContent = subText;
+    wrap.appendChild(t); wrap.appendChild(s);
+
+    if (related.length === 0) {
+      var hint = document.createElement('p');
+      hint.className = 'arch-info-hint';
+      hint.textContent = 'No stated or inferred relationships for this node.';
+      wrap.appendChild(hint);
+    } else {
+      var ul = document.createElement('ul');
+      ul.className = 'arch-rel-list';
+      related.forEach(function (rec) {
+        var e = rec.edge;
+        var info = otherInfo(e, id, isBoxNode);
+        var li = document.createElement('li');
+        li.className = 'arch-rel-item ' + e.kind;
+        var head = document.createElement('div');
+        head.className = 'arch-rel-head';
+        head.textContent = info.dir + ' ' + info.label;
+        var desc = document.createElement('p');
+        desc.className = 'arch-rel-desc';
+        desc.textContent = (e.kind === 'documented' ? 'TC-documented' : 'Inferred') + ' — ' + e.label;
+        li.appendChild(head);
+        li.appendChild(desc);
+        ul.appendChild(li);
+      });
+      wrap.appendChild(ul);
+    }
+    infoBody.innerHTML = '';
+    while (wrap.firstChild) infoBody.appendChild(wrap.firstChild);
+  }
+
+  Object.keys(nodeEls).forEach(function (id) {
+    var node = nodeEls[id].el;
+    node.addEventListener('pointerenter', function () { if (!pinnedId) setActive(id); });
+    node.addEventListener('pointerleave', function () { if (!pinnedId) setActive(null); });
+    node.addEventListener('focus', function () { if (!pinnedId) setActive(id); });
+    node.addEventListener('blur', function () { if (!pinnedId) setActive(null); });
+    node.addEventListener('click', function (ev) {
+      ev.stopPropagation();
+      if (dragMoved) return;
+      pinnedId = (pinnedId === id) ? null : id;
+      setActive(pinnedId);
+    });
+  });
+
+  var canvas = document.getElementById('arch-canvas');
+  var tx = 0, ty = 0, scale = 1, dragging = false, dragMoved = false, lastX = 0, lastY = 0;
+
+  function applyTransform() { viewport.setAttribute('transform', 'translate(' + tx + ',' + ty + ') scale(' + scale + ')'); }
+
+  function fitView() {
+    var cw = canvas.clientWidth, ch = canvas.clientHeight, pad = 40;
+    var s = Math.min((cw - pad * 2) / totalW, (ch - pad * 2) / totalH);
+    s = Math.max(0.25, Math.min(s, 1.5));
+    scale = s;
+    tx = cw / 2 - ((minLeft + maxRight) / 2) * s;
+    ty = ch / 2 - (totalH / 2) * s;
+    applyTransform();
+  }
+
+  canvas.addEventListener('pointerdown', function (ev) {
+    dragging = true; dragMoved = false; lastX = ev.clientX; lastY = ev.clientY;
+    canvas.classList.add('dragging');
+    canvas.setPointerCapture(ev.pointerId);
+  });
+  canvas.addEventListener('pointermove', function (ev) {
+    if (!dragging) return;
+    var dx = ev.clientX - lastX, dy = ev.clientY - lastY;
+    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) dragMoved = true;
+    tx += dx; ty += dy; lastX = ev.clientX; lastY = ev.clientY;
+    applyTransform();
+  });
+  canvas.addEventListener('pointerup', function (ev) {
+    dragging = false; canvas.classList.remove('dragging');
+    if (!dragMoved && (ev.target === canvas || ev.target === svg)) { pinnedId = null; setActive(null); }
+  });
+  canvas.addEventListener('pointerleave', function () { dragging = false; canvas.classList.remove('dragging'); });
+  canvas.addEventListener('wheel', function (ev) {
+    ev.preventDefault();
+    var rect = canvas.getBoundingClientRect();
+    var mx = ev.clientX - rect.left, my = ev.clientY - rect.top;
+    var factor = ev.deltaY < 0 ? 1.1 : 0.9;
+    var newScale = Math.max(0.25, Math.min(2.5, scale * factor));
+    var contentX = (mx - tx) / scale, contentY = (my - ty) / scale;
+    tx = mx - contentX * newScale; ty = my - contentY * newScale; scale = newScale;
+    applyTransform();
+  }, { passive: false });
+
+  var resetBtn = document.getElementById('arch-reset');
+  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; setActive(null); fitView(); });
+  window.addEventListener('resize', fitView);
+  fitView();
+})();

--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -66,24 +66,120 @@
   };
 
   var EDGES = [
-    { from: "CHR", to: "MDM", label: "full compatibility" },
-    { from: "CHR", to: "MSM", label: "full compatibility" },
-    { from: "MDM", to: "MSM", label: "metadata, security, clinical info" },
-    { from: "PHJM", to: "CHR", label: "integration" },
-    { from: "PHJM", to: "MSM", label: "integration" },
-    { from: "PHJM", to: "MDM", label: "integration" },
-    { from: "CHR.EpisodeOfCare", to: "PHJM.EpisodeOfCare", label: "shares this resource type" },
-    { from: "CHR.Condition", to: "PHJM.Condition", label: "shares this resource type" },
-    { from: "CHR.Observation", to: "PHJM.Observation", label: "shares this resource type" },
-    { from: "LAB.Observation", to: "CHR.Observation", label: "lab results" },
-    { from: "REFERRALS", to: "LAB.ServiceRequest", label: "referral request" },
-    { from: "CHR.Procedure", to: "REIMB.Procedure", label: "shares this resource type" },
-    { from: "CHR.Condition", to: "REIMB.Condition", label: "shares this resource type" },
-    { from: "CHR.Observation", to: "REIMB.Observation", label: "shares this resource type" },
-    { from: "PHJM.Encounter", to: "REIMB.Encounter", label: "shares this resource type" },
-    { from: "PHJM.CarePlan", to: "REIMB.CarePlan", label: "shares this resource type" },
-    { from: "PHJM.Questionnaire", to: "SCREEN.Questionnaire", label: "shares this resource type" }
+    { from: "CHR", to: "MDM", kind: "fullCompat" },
+    { from: "CHR", to: "MSM", kind: "fullCompat" },
+    { from: "MDM", to: "MSM", kind: "metaSecClinical" },
+    { from: "PHJM", to: "CHR", kind: "integration" },
+    { from: "PHJM", to: "MSM", kind: "integration" },
+    { from: "PHJM", to: "MDM", kind: "integration" },
+    { from: "CHR.EpisodeOfCare", to: "PHJM.EpisodeOfCare", kind: "sharesType" },
+    { from: "CHR.Condition", to: "PHJM.Condition", kind: "sharesType" },
+    { from: "CHR.Observation", to: "PHJM.Observation", kind: "sharesType" },
+    { from: "LAB.Observation", to: "CHR.Observation", kind: "labResults" },
+    { from: "REFERRALS", to: "LAB.ServiceRequest", kind: "referralRequest" },
+    { from: "CHR.Procedure", to: "REIMB.Procedure", kind: "sharesType" },
+    { from: "CHR.Condition", to: "REIMB.Condition", kind: "sharesType" },
+    { from: "CHR.Observation", to: "REIMB.Observation", kind: "sharesType" },
+    { from: "PHJM.Encounter", to: "REIMB.Encounter", kind: "sharesType" },
+    { from: "PHJM.CarePlan", to: "REIMB.CarePlan", kind: "sharesType" },
+    { from: "PHJM.Questionnaire", to: "SCREEN.Questionnaire", kind: "sharesType" }
   ];
+
+  // Everything the diagram renders as prose, per page language. The publisher
+  // sets <html lang="..."> and copies this file into every language directory,
+  // so one file serves en/ru/uz, following the same STRINGS[lang] || STRINGS.en
+  // convention as forms-renderer.js. Component wording matches the section
+  // headings in each language's components.md so page and diagram agree. FHIR
+  // resource type names (Patient, Observation ...) are never translated, and
+  // English falls through to the short/label already on COMPONENTS above.
+  var STRINGS = {
+    en: {
+      comp: {},
+      edge: {
+        fullCompat: "full compatibility",
+        metaSecClinical: "metadata, security, clinical info",
+        integration: "integration",
+        sharesType: "shares this resource type",
+        labResults: "lab results",
+        referralRequest: "referral request"
+      },
+      noRelations: "No stated or inferred relationships for this node.",
+      profiledTitle: "Profiled in this IG",
+      unprofiledTitle: "Named, not yet profiled",
+      resourceCount: function (n) { return n + (n === 1 ? " resource" : " resources"); }
+    },
+    ru: {
+      comp: {
+        MDM: { short: "MDM", label: "Управление основными данными (MDM)" },
+        MSM: { short: "MSM", label: "Управление метаданными и безопасностью (MSM)" },
+        CHR: { short: "CHR", label: "Электронные медицинские записи (CHR)" },
+        PHJM: { short: "PHJM", label: "Управление клиническим маршрутом пациента (PHJM)" },
+        LAB: { short: "Лаборатория", label: "Лаборатория" },
+        REFERRALS: { short: "Направления", label: "Направления" },
+        REIMB: { short: "Реимбурсация", label: "Реимбурсация" },
+        SCREEN: { short: "Графики скрининга", label: "Управление графиками скрининга" },
+        VACC: { short: "Вакцинация", label: "Управление вакцинацией" }
+      },
+      edge: {
+        fullCompat: "полная совместимость",
+        metaSecClinical: "метаданные, безопасность, клиническая информация",
+        integration: "интеграция",
+        sharesType: "общий тип ресурса",
+        labResults: "результаты лабораторных исследований",
+        referralRequest: "запрос по направлению"
+      },
+      noRelations: "Для этого узла нет заявленных или предполагаемых связей.",
+      profiledTitle: "Профилировано в этом руководстве",
+      unprofiledTitle: "Упомянуто, но ещё не профилировано",
+      // 1 ресурс / 2-4 ресурса / 5+ ресурсов, with the 11-14 exception.
+      resourceCount: function (n) {
+        var m10 = n % 10, m100 = n % 100;
+        if (m10 === 1 && m100 !== 11) return n + " ресурс";
+        if (m10 >= 2 && m10 <= 4 && (m100 < 12 || m100 > 14)) return n + " ресурса";
+        return n + " ресурсов";
+      }
+    },
+    uz: {
+      comp: {
+        MDM: { short: "MDM", label: "Asosiy ma'lumotlarni boshqarish (MDM)" },
+        MSM: { short: "MSM", label: "Metama'lumotlar va xavfsizlikni boshqarish (MSM)" },
+        CHR: { short: "CHR", label: "Elektron tibbiy yozuvlar (CHR)" },
+        PHJM: { short: "PHJM", label: "Bemorning klinik marshrutini boshqarish (PHJM)" },
+        LAB: { short: "Laboratoriya", label: "Laboratoriya" },
+        REFERRALS: { short: "Yo'llanmalar", label: "Yo'llanmalar" },
+        REIMB: { short: "Reimbursatsiya", label: "Reimbursatsiya" },
+        SCREEN: { short: "Skrining jadvallari", label: "Skrining jadvallarini boshqarish" },
+        VACC: { short: "Vaksinatsiya", label: "Vaksinatsiyani boshqarish" }
+      },
+      edge: {
+        fullCompat: "to'liq moslik",
+        metaSecClinical: "metama'lumotlar, xavfsizlik, klinik ma'lumot",
+        integration: "integratsiya",
+        sharesType: "umumiy resurs turi",
+        labResults: "laboratoriya natijalari",
+        referralRequest: "yo'llanma so'rovi"
+      },
+      noRelations: "Bu tugun uchun belgilangan yoki taxmin qilingan aloqalar yo'q.",
+      profiledTitle: "Ushbu qo'llanmada profillangan",
+      unprofiledTitle: "Nomlangan, lekin hali profillanmagan",
+      resourceCount: function (n) { return n + " ta resurs"; }
+    }
+  };
+
+  var LANG = (document.documentElement.getAttribute("lang") || "en").slice(0, 2).toLowerCase();
+  var T = STRINGS[LANG] || STRINGS.en;
+
+  function compShort(id) {
+    var c = T.comp && T.comp[id];
+    return (c && c.short) || COMPONENTS[id].short;
+  }
+  function compLabel(id) {
+    var c = T.comp && T.comp[id];
+    return (c && c.label) || COMPONENTS[id].label;
+  }
+  function edgeLabel(e) {
+    return (T.edge && T.edge[e.kind]) || STRINGS.en.edge[e.kind];
+  }
 
   var BOX_W = 220, PILL_H = 26, PILL_GAP = 6, PILL_INSET = 10,
       TITLE_H = 30, PAD_TOP = 8, PAD_BOTTOM = 10, EMPTY_H = 46,
@@ -193,7 +289,7 @@
     }
     g.appendChild(r);
 
-    var label = isBox ? COMPONENTS[id].short : data.name;
+    var label = isBox ? compShort(id) : data.name;
     var text = el('text', {
       x: isBox ? rect.x + 10 : rect.x + rect.w / 2,
       y: isBox ? rect.y + 19 : rect.y + rect.h / 2 + 4,
@@ -206,7 +302,7 @@
     text.textContent = label;
     g.appendChild(text);
 
-    g.setAttribute('aria-label', isBox ? COMPONENTS[id].label : (data.name + ' — ' + COMPONENTS[data.compId].label));
+    g.setAttribute('aria-label', isBox ? compLabel(id) : (data.name + ' — ' + compLabel(data.compId)));
     nodeLayer.appendChild(g);
     nodeEls[id] = { el: g };
   }
@@ -239,7 +335,7 @@
     var fromMatches = isBox ? edge.fromR.compId === id : edge.fromR.id === id;
     var other = fromMatches ? edge.toR : edge.fromR;
     var dir = edge.isBoxLevel ? '↔' : (fromMatches ? '→' : '←');
-    var label = other.kind === 'pill' ? (pills[other.id].name + ' · ' + COMPONENTS[other.compId].short) : COMPONENTS[other.compId].label;
+    var label = other.kind === 'pill' ? (pills[other.id].name + ' · ' + compShort(other.compId)) : compLabel(other.compId);
     return { dir: dir, label: label };
   }
 
@@ -268,8 +364,8 @@
       nodeEls[nid].el.classList.toggle('active', nid === id);
     });
 
-    var titleText = isBox ? COMPONENTS[id].short : pills[id].name;
-    var subText = isBox ? COMPONENTS[id].label : COMPONENTS[pills[id].compId].label;
+    var titleText = isBox ? compShort(id) : pills[id].name;
+    var subText = isBox ? compLabel(id) : compLabel(pills[id].compId);
     var wrap = document.createElement('div');
     var t = document.createElement('p'); t.className = 'arch-info-title'; t.textContent = titleText;
     var s = document.createElement('p'); s.className = 'arch-info-sub'; s.textContent = subText;
@@ -278,7 +374,7 @@
     if (related.length === 0) {
       var hint = document.createElement('p');
       hint.className = 'arch-info-hint';
-      hint.textContent = 'No stated or inferred relationships for this node.';
+      hint.textContent = T.noRelations;
       wrap.appendChild(hint);
     } else {
       var ul = document.createElement('ul');
@@ -293,7 +389,7 @@
         head.textContent = info.dir + ' ' + info.label;
         var desc = document.createElement('p');
         desc.className = 'arch-rel-desc';
-        desc.textContent = e.label;
+        desc.textContent = edgeLabel(e);
         li.appendChild(head);
         li.appendChild(desc);
         ul.appendChild(li);
@@ -318,9 +414,9 @@
 
     var wrap = document.createElement('div');
     var t = document.createElement('p'); t.className = 'arch-info-title';
-    t.textContent = legendKind === 'profiled' ? 'Profiled in this IG' : 'Named, not yet profiled';
+    t.textContent = legendKind === 'profiled' ? T.profiledTitle : T.unprofiledTitle;
     var s = document.createElement('p'); s.className = 'arch-info-sub';
-    s.textContent = matchCount + (matchCount === 1 ? ' resource' : ' resources');
+    s.textContent = T.resourceCount(matchCount);
     wrap.appendChild(t); wrap.appendChild(s);
     infoBody.innerHTML = '';
     while (wrap.firstChild) infoBody.appendChild(wrap.firstChild);

--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -1,9 +1,8 @@
 /*
  * Interactive resource-flow diagram for the Components page: which FHIR
  * resources each component owns, and which of those resources plausibly
- * flow to another component. Solid edges are relationships stated in the
- * components' Technical Projects; dashed edges are inferred from shared
- * resource types.
+ * connect to another component. Plain lines are component-to-component
+ * integration; arrows are a specific resource flowing between components.
  *
  * This file lives in input/images/ (copied verbatim to output/ and to every
  * language directory) and is loaded from the components page. It must stay
@@ -12,7 +11,11 @@
  *
  * Data mirrors input/images-source/resource-relationships.plantuml and the
  * component-to-component relationships documented in each component's
- * Technical Project (see components.md).
+ * Technical Project (see components.md). Internally, some of these edges are
+ * stated verbatim in a Technical Project and others are inferred from two
+ * components sharing a FHIR resource type - but that provenance is an
+ * editorial/audit detail, not something readers of this public page need to
+ * weigh, so it is intentionally not tracked or displayed per edge here.
  */
 (function () {
   var svgNS = 'http://www.w3.org/2000/svg';
@@ -63,23 +66,23 @@
   };
 
   var EDGES = [
-    { from: "CHR", to: "MDM", kind: "documented", label: "full compatibility" },
-    { from: "CHR", to: "MSM", kind: "documented", label: "full compatibility" },
-    { from: "MDM", to: "MSM", kind: "documented", label: "metadata, security, clinical info" },
-    { from: "PHJM", to: "CHR", kind: "documented", label: "integration" },
-    { from: "PHJM", to: "MSM", kind: "documented", label: "integration" },
-    { from: "PHJM", to: "MDM", kind: "documented", label: "integration" },
-    { from: "CHR.EpisodeOfCare", to: "PHJM.EpisodeOfCare", kind: "inferred", label: "inferred" },
-    { from: "CHR.Condition", to: "PHJM.Condition", kind: "inferred", label: "inferred" },
-    { from: "CHR.Observation", to: "PHJM.Observation", kind: "inferred", label: "inferred" },
-    { from: "LAB.Observation", to: "CHR.Observation", kind: "inferred", label: "lab results — inferred" },
-    { from: "REFERRALS", to: "LAB.ServiceRequest", kind: "inferred", label: "referral request — inferred" },
-    { from: "CHR.Procedure", to: "REIMB.Procedure", kind: "inferred", label: "inferred" },
-    { from: "CHR.Condition", to: "REIMB.Condition", kind: "inferred", label: "inferred" },
-    { from: "CHR.Observation", to: "REIMB.Observation", kind: "inferred", label: "inferred" },
-    { from: "PHJM.Encounter", to: "REIMB.Encounter", kind: "inferred", label: "inferred" },
-    { from: "PHJM.CarePlan", to: "REIMB.CarePlan", kind: "inferred", label: "inferred" },
-    { from: "PHJM.Questionnaire", to: "SCREEN.Questionnaire", kind: "inferred", label: "inferred" }
+    { from: "CHR", to: "MDM", label: "full compatibility" },
+    { from: "CHR", to: "MSM", label: "full compatibility" },
+    { from: "MDM", to: "MSM", label: "metadata, security, clinical info" },
+    { from: "PHJM", to: "CHR", label: "integration" },
+    { from: "PHJM", to: "MSM", label: "integration" },
+    { from: "PHJM", to: "MDM", label: "integration" },
+    { from: "CHR.EpisodeOfCare", to: "PHJM.EpisodeOfCare", label: "shares this resource type" },
+    { from: "CHR.Condition", to: "PHJM.Condition", label: "shares this resource type" },
+    { from: "CHR.Observation", to: "PHJM.Observation", label: "shares this resource type" },
+    { from: "LAB.Observation", to: "CHR.Observation", label: "lab results" },
+    { from: "REFERRALS", to: "LAB.ServiceRequest", label: "referral request" },
+    { from: "CHR.Procedure", to: "REIMB.Procedure", label: "shares this resource type" },
+    { from: "CHR.Condition", to: "REIMB.Condition", label: "shares this resource type" },
+    { from: "CHR.Observation", to: "REIMB.Observation", label: "shares this resource type" },
+    { from: "PHJM.Encounter", to: "REIMB.Encounter", label: "shares this resource type" },
+    { from: "PHJM.CarePlan", to: "REIMB.CarePlan", label: "shares this resource type" },
+    { from: "PHJM.Questionnaire", to: "SCREEN.Questionnaire", label: "shares this resource type" }
   ];
 
   var BOX_W = 220, PILL_H = 26, PILL_GAP = 6, PILL_INSET = 10,
@@ -122,7 +125,11 @@
   }
   function rectOf(r) { return r.kind === "pill" ? pills[r.id] : boxes[r.id]; }
 
-  EDGES.forEach(function (e) { e.fromR = resolveEndpoint(e.from); e.toR = resolveEndpoint(e.to); });
+  EDGES.forEach(function (e) {
+    e.fromR = resolveEndpoint(e.from);
+    e.toR = resolveEndpoint(e.to);
+    e.isBoxLevel = e.fromR.kind === "box" && e.toR.kind === "box";
+  });
 
   function boundaryPoint(rect, other) {
     var acx = rect.x + rect.w / 2, acy = rect.y + rect.h / 2;
@@ -146,9 +153,9 @@
   if (!svg) return;
 
   var defs = el('defs', {});
-  var arrowInferred = el('marker', { id: 'arch-arrow-inferred', viewBox: '0 0 10 10', refX: '8', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto' });
-  arrowInferred.appendChild(el('path', { d: 'M0,0 L10,5 L0,10 z' }));
-  defs.appendChild(arrowInferred);
+  var arrow = el('marker', { id: 'arch-arrow', viewBox: '0 0 10 10', refX: '8', refY: '5', markerWidth: '7', markerHeight: '7', orient: 'auto' });
+  arrow.appendChild(el('path', { d: 'M0,0 L10,5 L0,10 z' }));
+  defs.appendChild(arrow);
   svg.appendChild(defs);
 
   var viewport = el('g', { id: 'arch-viewport' });
@@ -163,11 +170,10 @@
     var p1 = boundaryPoint(rectOf(e.fromR), rectOf(e.toR));
     var p2 = boundaryPoint(rectOf(e.toR), rectOf(e.fromR));
     var path = el('path', { d: curvePath(p1, p2), class: 'arch-edge', fill: 'none' });
-    path.style.stroke = e.kind === 'documented' ? 'var(--blueprint)' : 'var(--pencil)';
-    path.setAttribute('stroke-width', e.kind === 'documented' ? '2' : '1.5');
-    if (e.kind === 'inferred') {
-      path.setAttribute('stroke-dasharray', '5,4');
-      path.setAttribute('marker-end', 'url(#arch-arrow-inferred)');
+    path.style.stroke = 'var(--blueprint)';
+    path.setAttribute('stroke-width', e.isBoxLevel ? '2' : '1.5');
+    if (!e.isBoxLevel) {
+      path.setAttribute('marker-end', 'url(#arch-arrow)');
     }
     edgeLayer.appendChild(path);
     edgeEls.push({ el: path, edge: e });
@@ -214,13 +220,11 @@
   var statEls = {
     components: document.getElementById('arch-stat-components'),
     resources: document.getElementById('arch-stat-resources'),
-    documented: document.getElementById('arch-stat-documented'),
-    inferred: document.getElementById('arch-stat-inferred')
+    relationships: document.getElementById('arch-stat-relationships')
   };
   if (statEls.components) statEls.components.textContent = Object.keys(boxes).length;
   if (statEls.resources) statEls.resources.textContent = Object.keys(pills).length;
-  if (statEls.documented) statEls.documented.textContent = EDGES.filter(function (e) { return e.kind === 'documented'; }).length;
-  if (statEls.inferred) statEls.inferred.textContent = EDGES.filter(function (e) { return e.kind === 'inferred'; }).length;
+  if (statEls.relationships) statEls.relationships.textContent = EDGES.length;
 
   var defaultInfoHTML = infoBody.innerHTML;
 
@@ -234,33 +238,38 @@
   function otherInfo(edge, id, isBox) {
     var fromMatches = isBox ? edge.fromR.compId === id : edge.fromR.id === id;
     var other = fromMatches ? edge.toR : edge.fromR;
-    var dir = edge.kind === 'documented' ? '↔' : (fromMatches ? '→' : '←');
+    var dir = edge.isBoxLevel ? '↔' : (fromMatches ? '→' : '←');
     var label = other.kind === 'pill' ? (pills[other.id].name + ' · ' + COMPONENTS[other.compId].short) : COMPONENTS[other.compId].label;
     return { dir: dir, label: label };
   }
 
+  function clearHighlight() {
+    edgeEls.forEach(function (rec) { rec.el.classList.remove('dim'); });
+    Object.keys(nodeEls).forEach(function (nid) {
+      nodeEls[nid].el.classList.remove('dim', 'active');
+    });
+  }
+
   function setActive(id) {
-    var isBox = id ? !!boxes[id] : false;
-    var related = id ? edgesFor(id, isBox) : [];
+    if (!id) { clearHighlight(); infoBody.innerHTML = defaultInfoHTML; return; }
+
+    var isBox = !!boxes[id];
+    var related = edgesFor(id, isBox);
     var activeNodeIds = {};
-    if (id) activeNodeIds[id] = true;
+    activeNodeIds[id] = true;
     related.forEach(function (rec) { activeNodeIds[rec.edge.fromR.id] = true; activeNodeIds[rec.edge.toR.id] = true; });
 
     edgeEls.forEach(function (rec) {
-      var isActive = !id || related.indexOf(rec) !== -1;
-      rec.el.classList.toggle('dim', !!id && !isActive);
+      rec.el.classList.toggle('dim', related.indexOf(rec) === -1);
     });
     Object.keys(nodeEls).forEach(function (nid) {
-      var isActive = !id || nid === id || activeNodeIds[nid];
-      nodeEls[nid].el.classList.toggle('dim', !!id && !isActive);
-      nodeEls[nid].el.classList.toggle('active', !!id && nid === id);
+      var isActive = nid === id || activeNodeIds[nid];
+      nodeEls[nid].el.classList.toggle('dim', !isActive);
+      nodeEls[nid].el.classList.toggle('active', nid === id);
     });
 
-    if (!id) { infoBody.innerHTML = defaultInfoHTML; return; }
-
-    var isBoxNode = !!boxes[id];
-    var titleText = isBoxNode ? COMPONENTS[id].short : pills[id].name;
-    var subText = isBoxNode ? COMPONENTS[id].label : COMPONENTS[pills[id].compId].label;
+    var titleText = isBox ? COMPONENTS[id].short : pills[id].name;
+    var subText = isBox ? COMPONENTS[id].label : COMPONENTS[pills[id].compId].label;
     var wrap = document.createElement('div');
     var t = document.createElement('p'); t.className = 'arch-info-title'; t.textContent = titleText;
     var s = document.createElement('p'); s.className = 'arch-info-sub'; s.textContent = subText;
@@ -276,21 +285,43 @@
       ul.className = 'arch-rel-list';
       related.forEach(function (rec) {
         var e = rec.edge;
-        var info = otherInfo(e, id, isBoxNode);
+        var info = otherInfo(e, id, isBox);
         var li = document.createElement('li');
-        li.className = 'arch-rel-item ' + e.kind;
+        li.className = 'arch-rel-item';
         var head = document.createElement('div');
         head.className = 'arch-rel-head';
         head.textContent = info.dir + ' ' + info.label;
         var desc = document.createElement('p');
         desc.className = 'arch-rel-desc';
-        desc.textContent = (e.kind === 'documented' ? 'TC-documented' : 'Inferred') + ' — ' + e.label;
+        desc.textContent = e.label;
         li.appendChild(head);
         li.appendChild(desc);
         ul.appendChild(li);
       });
       wrap.appendChild(ul);
     }
+    infoBody.innerHTML = '';
+    while (wrap.firstChild) infoBody.appendChild(wrap.firstChild);
+  }
+
+  function setLegendActive(legendKind) {
+    clearHighlight();
+    edgeEls.forEach(function (rec) { rec.el.classList.add('dim'); });
+    var matchCount = 0;
+    Object.keys(nodeEls).forEach(function (nid) {
+      if (boxes[nid]) { nodeEls[nid].el.classList.add('dim'); return; }
+      var match = legendKind === 'profiled' ? pills[nid].profiled : !pills[nid].profiled;
+      if (match) matchCount++;
+      nodeEls[nid].el.classList.toggle('dim', !match);
+      nodeEls[nid].el.classList.toggle('active', match);
+    });
+
+    var wrap = document.createElement('div');
+    var t = document.createElement('p'); t.className = 'arch-info-title';
+    t.textContent = legendKind === 'profiled' ? 'Profiled in this IG' : 'Named, not yet profiled';
+    var s = document.createElement('p'); s.className = 'arch-info-sub';
+    s.textContent = matchCount + (matchCount === 1 ? ' resource' : ' resources');
+    wrap.appendChild(t); wrap.appendChild(s);
     infoBody.innerHTML = '';
     while (wrap.firstChild) infoBody.appendChild(wrap.firstChild);
   }
@@ -309,9 +340,17 @@
     });
   });
 
+  var legendEls = document.querySelectorAll('.arch-legend [data-legend]');
+  Array.prototype.forEach.call(legendEls, function (legendEl) {
+    var legendKind = legendEl.getAttribute('data-legend');
+    legendEl.addEventListener('pointerenter', function () { if (!pinnedId) setLegendActive(legendKind); });
+    legendEl.addEventListener('pointerleave', function () { if (!pinnedId) setActive(null); });
+    legendEl.addEventListener('focus', function () { if (!pinnedId) setLegendActive(legendKind); });
+    legendEl.addEventListener('blur', function () { if (!pinnedId) setActive(null); });
+  });
+
   var canvas = document.getElementById('arch-canvas');
   var tx = 0, ty = 0, scale = 1, dragging = false, dragMoved = false, lastX = 0, lastY = 0;
-  var userAdjusted = false;
 
   function applyTransform() { viewport.setAttribute('transform', 'translate(' + tx + ',' + ty + ') scale(' + scale + ')'); }
 
@@ -333,7 +372,7 @@
   canvas.addEventListener('pointermove', function (ev) {
     if (!dragging) return;
     var dx = ev.clientX - lastX, dy = ev.clientY - lastY;
-    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) { dragMoved = true; userAdjusted = true; }
+    if (Math.abs(dx) > 2 || Math.abs(dy) > 2) dragMoved = true;
     tx += dx; ty += dy; lastX = ev.clientX; lastY = ev.clientY;
     applyTransform();
   });
@@ -350,22 +389,11 @@
     var newScale = Math.max(0.25, Math.min(2.5, scale * factor));
     var contentX = (mx - tx) / scale, contentY = (my - ty) / scale;
     tx = mx - contentX * newScale; ty = my - contentY * newScale; scale = newScale;
-    userAdjusted = true;
     applyTransform();
   }, { passive: false });
 
   var resetBtn = document.getElementById('arch-reset');
-  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; userAdjusted = false; setActive(null); fitView(); });
-
-  // The page's own layout (e.g. the floating table of contents) can still be
-  // settling after this script runs, changing the canvas's width out from
-  // under the initial fitView(). Re-fit on any size change until the reader
-  // has taken control (panned/zoomed), rather than relying on 'resize' alone.
-  function refitIfUntouched() { if (!userAdjusted) fitView(); }
-  if (window.ResizeObserver) {
-    new ResizeObserver(refitIfUntouched).observe(canvas);
-  } else {
-    window.addEventListener('resize', refitIfUntouched);
-  }
+  if (resetBtn) resetBtn.addEventListener('click', function () { pinnedId = null; setActive(null); fitView(); });
+  window.addEventListener('resize', fitView);
   fitView();
 })();

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -1,12 +1,13 @@
 ### How the components relate
 
-Each component below is described on its own; in practice several of them exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources plausibly flow between components. Solid blue lines are relationships stated in the components' Technical Projects (ТП); dashed grey lines are inferred from shared resource types and have not been separately confirmed. Drag to pan, scroll to zoom, and hover or tab to a resource or component to see its connections.
+Each component below is described on its own; in practice several of them exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
+
+<br clear="all"/>
 
 <style>
   .arch-diagram {
     --blueprint: #2255AA;
     --blueprint-soft: #dce7f6;
-    --pencil: #888888;
     --pencil-soft: #e6e6e6;
     --ink: #1b232a;
     --ink-soft: #5c6b74;
@@ -19,8 +20,8 @@ Each component below is described on its own; in practice several of them exchan
   }
   .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
   .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
-  .arch-legend .swatch-line { width: 18px; height: 0; border-top: 2px solid var(--blueprint); }
-  .arch-legend .swatch-line.inferred { border-top: 2px dashed var(--pencil); }
+  .arch-legend span[data-legend] { cursor: pointer; padding: 2px 4px; margin: -2px -4px; border-radius: 3px; }
+  .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
   .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
   .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
 
@@ -81,9 +82,7 @@ Each component below is described on its own; in practice several of them exchan
   }
   .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
   .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
-  .arch-rel-item { border-left: 2px solid var(--line); padding-left: 0.6rem; }
-  .arch-rel-item.documented { border-left-color: var(--blueprint); }
-  .arch-rel-item.inferred { border-left-color: var(--pencil); }
+  .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
   .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
   .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
 
@@ -93,7 +92,7 @@ Each component below is described on its own; in practice several of them exchan
   .arch-edge { transition: opacity 0.15s ease; }
   .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
   .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
-  #arch-arrow-inferred path { fill: var(--pencil); }
+  #arch-arrow path { fill: var(--blueprint); }
 
   @media (prefers-reduced-motion: reduce) {
     .arch-node rect, .arch-edge { transition: none; }
@@ -107,10 +106,8 @@ Each component below is described on its own; in practice several of them exchan
 
 <div class="arch-diagram">
   <div class="arch-legend">
-    <span><span class="swatch-line"></span> TC-documented</span>
-    <span><span class="swatch-line inferred"></span> inferred</span>
-    <span><span class="swatch-box"></span> profiled in this IG</span>
-    <span><span class="swatch-box pale"></span> named, not yet profiled</span>
+    <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> profiled in this IG</span>
+    <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> named, not yet profiled</span>
   </div>
   <div class="arch-toolbar">
     <button type="button" id="arch-reset" class="arch-btn">Reset view</button>
@@ -121,11 +118,10 @@ Each component below is described on its own; in practice several of them exchan
     </div>
     <aside class="arch-info" id="arch-info">
       <div id="arch-info-body">
-        <p class="arch-info-hint">Hover or tab to a resource or component to see what it connects to.</p>
+        <p class="arch-info-hint">Hover or tab to a resource, component, or legend item to see what it connects to.</p>
         <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
         <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
-        <div class="arch-stat-row"><span>Documented links</span><span class="arch-stat-n" id="arch-stat-documented">–</span></div>
-        <div class="arch-stat-row"><span>Inferred flows</span><span class="arch-stat-n" id="arch-stat-inferred">–</span></div>
+        <div class="arch-stat-row"><span>Relationships</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
       </div>
     </aside>
   </div>

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -25,19 +25,6 @@ Each component below is described on its own; in practice several of them exchan
   .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
   .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
 
-  .arch-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.5rem; }
-  .arch-btn {
-    background: var(--paper-raised);
-    border: 1px solid var(--line);
-    color: var(--blueprint);
-    font-family: var(--mono-font);
-    font-size: 0.72rem;
-    letter-spacing: 0.03em;
-    padding: 0.35rem 0.7rem;
-    cursor: pointer;
-  }
-  .arch-btn:hover { background: var(--blueprint-soft); }
-
   .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
 
   .arch-canvas {
@@ -108,9 +95,6 @@ Each component below is described on its own; in practice several of them exchan
   <div class="arch-legend">
     <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> profiled in this IG</span>
     <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> named, not yet profiled</span>
-  </div>
-  <div class="arch-toolbar">
-    <button type="button" id="arch-reset" class="arch-btn">Reset view</button>
   </div>
   <div class="arch-wrap">
     <div class="arch-canvas" id="arch-canvas">

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -1,6 +1,51 @@
+### At a glance
+
+The Digital Health Platform is made up of 19 components, each covering a distinct part of the national healthcare system.
+
+<style>
+  .component-index { display: flex; flex-wrap: wrap; gap: 0.5rem 0.6rem; margin: 0.75rem 0 0.5rem; }
+  .component-index a {
+    display: inline-block;
+    padding: 0.4rem 0.9rem;
+    border: 1px solid #c9d2d6;
+    border-radius: 999px;
+    background: #f4f7f9;
+    color: #2255AA;
+    font-size: 0.85rem;
+    text-decoration: none;
+    transition: background 0.15s ease, border-color 0.15s ease;
+  }
+  .component-index a:hover, .component-index a:focus-visible {
+    background: #dce7f6;
+    border-color: #2255AA;
+  }
+</style>
+
+<div class="component-index">
+  <a href="#ambulance">Ambulance</a>
+  <a href="#appointment-and-scheduling">Appointment and Scheduling</a>
+  <a href="#blood-management">Blood Management</a>
+  <a href="#clinical-decision-support">Clinical Decision Support</a>
+  <a href="#clinical-health-records-chr">Clinical Health Records (CHR)</a>
+  <a href="#diagnostics-and-imaging">Diagnostics and Imaging</a>
+  <a href="#laboratory">Laboratory</a>
+  <a href="#master-data-management-mdm">Master Data Management (MDM)</a>
+  <a href="#metadata-and-security-management-msm">Metadata and Security Management (MSM)</a>
+  <a href="#nursing">Nursing</a>
+  <a href="#patient-health-journey-management">Patient health journey management</a>
+  <a href="#prescription">Prescription</a>
+  <a href="#public-health-reporting">Public Health Reporting</a>
+  <a href="#quality-assurance">Quality Assurance</a>
+  <a href="#referrals">Referrals</a>
+  <a href="#reimbursement">Reimbursement</a>
+  <a href="#screening-schedules-management">Screening Schedules Management</a>
+  <a href="#supplies">Supplies</a>
+  <a href="#vaccination-management">Vaccination Management</a>
+</div>
+
 ### Cross-component resource architecture
 
-Each component below is described on its own; in practice several of them exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
+In practice, several of the components above exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
 
 <br clear="all"/>
 

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -1,4 +1,4 @@
-### How the components relate
+### Cross-component resource architecture
 
 Each component below is described on its own; in practice several of them exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
 

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -1,161 +1,4 @@
-### At a glance
-
-The Digital Health Platform is made up of 19 components, each covering a distinct part of the national healthcare system.
-
-<style>
-  .component-index { display: flex; flex-wrap: wrap; gap: 0.5rem 0.6rem; margin: 0.75rem 0 0.5rem; }
-  .component-index a {
-    display: inline-block;
-    padding: 0.4rem 0.9rem;
-    border: 1px solid #c9d2d6;
-    border-radius: 999px;
-    background: #f4f7f9;
-    color: #2255AA;
-    font-size: 0.85rem;
-    text-decoration: none;
-    transition: background 0.15s ease, border-color 0.15s ease;
-  }
-  .component-index a:hover, .component-index a:focus-visible {
-    background: #dce7f6;
-    border-color: #2255AA;
-  }
-</style>
-
-<div class="component-index">
-  <a href="#ambulance">Ambulance</a>
-  <a href="#appointment-and-scheduling">Appointment and Scheduling</a>
-  <a href="#blood-management">Blood Management</a>
-  <a href="#clinical-decision-support">Clinical Decision Support</a>
-  <a href="#clinical-health-records-chr">Clinical Health Records (CHR)</a>
-  <a href="#diagnostics-and-imaging">Diagnostics and Imaging</a>
-  <a href="#laboratory">Laboratory</a>
-  <a href="#master-data-management-mdm">Master Data Management (MDM)</a>
-  <a href="#metadata-and-security-management-msm">Metadata and Security Management (MSM)</a>
-  <a href="#nursing">Nursing</a>
-  <a href="#patient-health-journey-management">Patient health journey management</a>
-  <a href="#prescription">Prescription</a>
-  <a href="#public-health-reporting">Public Health Reporting</a>
-  <a href="#quality-assurance">Quality Assurance</a>
-  <a href="#referrals">Referrals</a>
-  <a href="#reimbursement">Reimbursement</a>
-  <a href="#screening-schedules-management">Screening Schedules Management</a>
-  <a href="#supplies">Supplies</a>
-  <a href="#vaccination-management">Vaccination Management</a>
-</div>
-
-### Cross-component resource architecture
-
-In practice, several of the components above exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
-
-<br clear="all"/>
-
-<style>
-  .arch-diagram {
-    --blueprint: #2255AA;
-    --blueprint-soft: #dce7f6;
-    --pencil-soft: #e6e6e6;
-    --ink: #1b232a;
-    --ink-soft: #5c6b74;
-    --paper: #ffffff;
-    --paper-raised: #f4f7f9;
-    --line: #c9d2d6;
-    --grid: rgba(27, 35, 42, 0.05);
-    --mono-font: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
-    margin: 1.5rem 0;
-  }
-  .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
-  .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
-  .arch-legend span[data-legend] { cursor: pointer; padding: 2px 4px; margin: -2px -4px; border-radius: 3px; }
-  .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
-  .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
-  .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
-
-  .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
-
-  .arch-canvas {
-    flex: 1 1 480px;
-    height: 640px;
-    position: relative;
-    overflow: hidden;
-    border: 1px solid var(--line);
-    cursor: grab;
-    touch-action: none;
-    background-color: var(--paper);
-    background-image:
-      linear-gradient(var(--grid) 1px, transparent 1px),
-      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
-    background-size: 24px 24px;
-  }
-  .arch-canvas.dragging { cursor: grabbing; }
-  .arch-canvas svg { display: block; }
-
-  .arch-info {
-    flex: 0 0 240px;
-    min-width: 220px;
-    border: 1px solid var(--line);
-    background: var(--paper-raised);
-    padding: 0.9rem 1rem;
-    font-size: 0.82rem;
-    max-height: 640px;
-    overflow-y: auto;
-  }
-  .arch-info-hint { margin: 0 0 0.8rem; color: var(--ink-soft); font-size: 0.82rem; }
-  .arch-stat-row {
-    display: flex; justify-content: space-between; gap: 0.6rem;
-    padding: 0.28rem 0; border-bottom: 1px solid var(--line);
-    color: var(--ink-soft); font-size: 0.78rem;
-  }
-  .arch-stat-row:last-child { border-bottom: none; }
-  .arch-stat-n { color: var(--ink); font-weight: 600; font-family: var(--mono-font); }
-
-  .arch-info-title {
-    font-family: var(--mono-font);
-    font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
-  }
-  .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
-  .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
-  .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
-  .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
-  .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
-
-  .arch-node { cursor: pointer; }
-  .arch-node rect { transition: opacity 0.15s ease; }
-  .arch-node text { pointer-events: none; }
-  .arch-edge { transition: opacity 0.15s ease; }
-  .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
-  .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
-  #arch-arrow path { fill: var(--blueprint); }
-
-  @media (prefers-reduced-motion: reduce) {
-    .arch-node rect, .arch-edge { transition: none; }
-  }
-
-  @media (max-width: 720px) {
-    .arch-canvas { height: 420px; }
-    .arch-info { flex-basis: 100%; }
-  }
-</style>
-
-<div class="arch-diagram">
-  <div class="arch-legend">
-    <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> profiled in this IG</span>
-    <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> named, not yet profiled</span>
-  </div>
-  <div class="arch-wrap">
-    <div class="arch-canvas" id="arch-canvas">
-      <svg id="arch-svg" width="100%" height="100%"></svg>
-    </div>
-    <aside class="arch-info" id="arch-info">
-      <div id="arch-info-body">
-        <p class="arch-info-hint">Hover or tab to a resource, component, or legend item to see what it connects to.</p>
-        <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
-        <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
-        <div class="arch-stat-row"><span>Relationships</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
-      </div>
-    </aside>
-  </div>
-</div>
-<script src="architecture-diagram.js"></script>
+See how these components relate to each other in the [cross-component resource architecture](#cross-component-resource-architecture) diagram at the end of this page.
 
 ### Ambulance
 \< add one paragraph description of the service here \>
@@ -313,4 +156,118 @@ The component ensures:
 - support of the full vaccination lifecycle (prescription, scheduling, administration, monitoring);
 - integration with Medical Information Systems and national immunization programs;
 - generation of analytics and reporting for monitoring population immunization coverage.
+
+### Cross-component resource architecture
+
+In practice, several of the components described above exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
+
+<br clear="all"/>
+
+<style>
+  .arch-diagram {
+    --blueprint: #2255AA;
+    --blueprint-soft: #dce7f6;
+    --pencil-soft: #e6e6e6;
+    --ink: #1b232a;
+    --ink-soft: #5c6b74;
+    --paper: #ffffff;
+    --paper-raised: #f4f7f9;
+    --line: #c9d2d6;
+    --grid: rgba(27, 35, 42, 0.05);
+    --mono-font: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    margin: 1.5rem 0;
+  }
+  .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .arch-legend span[data-legend] { cursor: pointer; padding: 2px 4px; margin: -2px -4px; border-radius: 3px; }
+  .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
+  .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
+  .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+
+  .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
+
+  .arch-canvas {
+    flex: 1 1 480px;
+    height: 640px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    cursor: grab;
+    touch-action: none;
+    background-color: var(--paper);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  .arch-canvas.dragging { cursor: grabbing; }
+  .arch-canvas svg { display: block; }
+
+  .arch-info {
+    flex: 0 0 240px;
+    min-width: 220px;
+    border: 1px solid var(--line);
+    background: var(--paper-raised);
+    padding: 0.9rem 1rem;
+    font-size: 0.82rem;
+    max-height: 640px;
+    overflow-y: auto;
+  }
+  .arch-info-hint { margin: 0 0 0.8rem; color: var(--ink-soft); font-size: 0.82rem; }
+  .arch-stat-row {
+    display: flex; justify-content: space-between; gap: 0.6rem;
+    padding: 0.28rem 0; border-bottom: 1px solid var(--line);
+    color: var(--ink-soft); font-size: 0.78rem;
+  }
+  .arch-stat-row:last-child { border-bottom: none; }
+  .arch-stat-n { color: var(--ink); font-weight: 600; font-family: var(--mono-font); }
+
+  .arch-info-title {
+    font-family: var(--mono-font);
+    font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
+  }
+  .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+  .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
+  .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
+  .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
+
+  .arch-node { cursor: pointer; }
+  .arch-node rect { transition: opacity 0.15s ease; }
+  .arch-node text { pointer-events: none; }
+  .arch-edge { transition: opacity 0.15s ease; }
+  .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
+  .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
+  #arch-arrow path { fill: var(--blueprint); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .arch-node rect, .arch-edge { transition: none; }
+  }
+
+  @media (max-width: 720px) {
+    .arch-canvas { height: 420px; }
+    .arch-info { flex-basis: 100%; }
+  }
+</style>
+
+<div class="arch-diagram">
+  <div class="arch-legend">
+    <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> profiled in this IG</span>
+    <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> named, not yet profiled</span>
+  </div>
+  <div class="arch-wrap">
+    <div class="arch-canvas" id="arch-canvas">
+      <svg id="arch-svg" width="100%" height="100%"></svg>
+    </div>
+    <aside class="arch-info" id="arch-info">
+      <div id="arch-info-body">
+        <p class="arch-info-hint">Hover or tab to a resource, component, or legend item to see what it connects to.</p>
+        <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
+        <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
+        <div class="arch-stat-row"><span>Relationships</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
+      </div>
+    </aside>
+  </div>
+</div>
+<script src="architecture-diagram.js"></script>
 

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -1,3 +1,137 @@
+### How the components relate
+
+Each component below is described on its own; in practice several of them exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources plausibly flow between components. Solid blue lines are relationships stated in the components' Technical Projects (ТП); dashed grey lines are inferred from shared resource types and have not been separately confirmed. Drag to pan, scroll to zoom, and hover or tab to a resource or component to see its connections.
+
+<style>
+  .arch-diagram {
+    --blueprint: #2255AA;
+    --blueprint-soft: #dce7f6;
+    --pencil: #888888;
+    --pencil-soft: #e6e6e6;
+    --ink: #1b232a;
+    --ink-soft: #5c6b74;
+    --paper: #ffffff;
+    --paper-raised: #f4f7f9;
+    --line: #c9d2d6;
+    --grid: rgba(27, 35, 42, 0.05);
+    --mono-font: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    margin: 1.5rem 0;
+  }
+  .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .arch-legend .swatch-line { width: 18px; height: 0; border-top: 2px solid var(--blueprint); }
+  .arch-legend .swatch-line.inferred { border-top: 2px dashed var(--pencil); }
+  .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
+  .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+
+  .arch-toolbar { display: flex; justify-content: flex-end; margin-bottom: 0.5rem; }
+  .arch-btn {
+    background: var(--paper-raised);
+    border: 1px solid var(--line);
+    color: var(--blueprint);
+    font-family: var(--mono-font);
+    font-size: 0.72rem;
+    letter-spacing: 0.03em;
+    padding: 0.35rem 0.7rem;
+    cursor: pointer;
+  }
+  .arch-btn:hover { background: var(--blueprint-soft); }
+
+  .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
+
+  .arch-canvas {
+    flex: 1 1 480px;
+    height: 640px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    cursor: grab;
+    touch-action: none;
+    background-color: var(--paper);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  .arch-canvas.dragging { cursor: grabbing; }
+  .arch-canvas svg { display: block; }
+
+  .arch-info {
+    flex: 0 0 240px;
+    min-width: 220px;
+    border: 1px solid var(--line);
+    background: var(--paper-raised);
+    padding: 0.9rem 1rem;
+    font-size: 0.82rem;
+    max-height: 640px;
+    overflow-y: auto;
+  }
+  .arch-info-hint { margin: 0 0 0.8rem; color: var(--ink-soft); font-size: 0.82rem; }
+  .arch-stat-row {
+    display: flex; justify-content: space-between; gap: 0.6rem;
+    padding: 0.28rem 0; border-bottom: 1px solid var(--line);
+    color: var(--ink-soft); font-size: 0.78rem;
+  }
+  .arch-stat-row:last-child { border-bottom: none; }
+  .arch-stat-n { color: var(--ink); font-weight: 600; font-family: var(--mono-font); }
+
+  .arch-info-title {
+    font-family: var(--mono-font);
+    font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
+  }
+  .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+  .arch-rel-item { border-left: 2px solid var(--line); padding-left: 0.6rem; }
+  .arch-rel-item.documented { border-left-color: var(--blueprint); }
+  .arch-rel-item.inferred { border-left-color: var(--pencil); }
+  .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
+  .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
+
+  .arch-node { cursor: pointer; }
+  .arch-node rect { transition: opacity 0.15s ease; }
+  .arch-node text { pointer-events: none; }
+  .arch-edge { transition: opacity 0.15s ease; }
+  .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
+  .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
+  #arch-arrow-inferred path { fill: var(--pencil); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .arch-node rect, .arch-edge { transition: none; }
+  }
+
+  @media (max-width: 720px) {
+    .arch-canvas { height: 420px; }
+    .arch-info { flex-basis: 100%; }
+  }
+</style>
+
+<div class="arch-diagram">
+  <div class="arch-legend">
+    <span><span class="swatch-line"></span> TC-documented</span>
+    <span><span class="swatch-line inferred"></span> inferred</span>
+    <span><span class="swatch-box"></span> profiled in this IG</span>
+    <span><span class="swatch-box pale"></span> named, not yet profiled</span>
+  </div>
+  <div class="arch-toolbar">
+    <button type="button" id="arch-reset" class="arch-btn">Reset view</button>
+  </div>
+  <div class="arch-wrap">
+    <div class="arch-canvas" id="arch-canvas">
+      <svg id="arch-svg" width="100%" height="100%"></svg>
+    </div>
+    <aside class="arch-info" id="arch-info">
+      <div id="arch-info-body">
+        <p class="arch-info-hint">Hover or tab to a resource or component to see what it connects to.</p>
+        <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
+        <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
+        <div class="arch-stat-row"><span>Documented links</span><span class="arch-stat-n" id="arch-stat-documented">–</span></div>
+        <div class="arch-stat-row"><span>Inferred flows</span><span class="arch-stat-n" id="arch-stat-inferred">–</span></div>
+      </div>
+    </aside>
+  </div>
+</div>
+<script src="architecture-diagram.js"></script>
+
 ### Ambulance
 \< add one paragraph description of the service here \>
 

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -259,14 +259,14 @@ In practice, several of the components described above exchange the same underly
     <div class="arch-canvas" id="arch-canvas">
       <svg id="arch-svg" width="100%" height="100%"></svg>
     </div>
-    <aside class="arch-info" id="arch-info">
+    <div class="arch-info" id="arch-info">
       <div id="arch-info-body">
         <p class="arch-info-hint">Hover or tab to a resource, component, or legend item to see what it connects to.</p>
         <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
         <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
         <div class="arch-stat-row"><span>Relationships</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
       </div>
-    </aside>
+    </div>
   </div>
 </div>
 <script src="architecture-diagram.js"></script>

--- a/input/translations/ru/pagecontent/components.md
+++ b/input/translations/ru/pagecontent/components.md
@@ -1,3 +1,5 @@
+Как эти компоненты связаны друг с другом, показано на диаграмме [межкомпонентной архитектуры ресурсов](#межкомпонентная-архитектура-ресурсов) в конце страницы.
+
 ### Скорая медицинская помощь
 \< добавить описание сервиса \>
 
@@ -181,3 +183,117 @@ CHR обеспечивает стандартизированное ведени
 - поддержку полного жизненного цикла вакцинации (назначение, планирование, проведение, наблюдение);
 - интеграцию с медицинскими информационными системами и национальными программами вакцинации;
 - формирование аналитики и отчетности для мониторинга уровня иммунизации населения.
+
+### Межкомпонентная архитектура ресурсов
+
+На практике несколько описанных выше компонентов обмениваются одними и теми же FHIR-ресурсами. Эта диаграмма спускается на уровень ресурсов: какими ресурсами владеет каждый компонент и какие из них связывают его с другим компонентом. Сплошные линии показывают широкую интеграцию двух компонентов, стрелки - передачу конкретного ресурса из одного компонента в другой. Перетаскивайте для перемещения, прокручивайте для масштабирования, наводите курсор или переходите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи.
+
+<br clear="all"/>
+
+<style>
+  .arch-diagram {
+    --blueprint: #2255AA;
+    --blueprint-soft: #dce7f6;
+    --pencil-soft: #e6e6e6;
+    --ink: #1b232a;
+    --ink-soft: #5c6b74;
+    --paper: #ffffff;
+    --paper-raised: #f4f7f9;
+    --line: #c9d2d6;
+    --grid: rgba(27, 35, 42, 0.05);
+    --mono-font: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    margin: 1.5rem 0;
+  }
+  .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .arch-legend span[data-legend] { cursor: pointer; padding: 2px 4px; margin: -2px -4px; border-radius: 3px; }
+  .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
+  .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
+  .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+
+  .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
+
+  .arch-canvas {
+    flex: 1 1 480px;
+    height: 640px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    cursor: grab;
+    touch-action: none;
+    background-color: var(--paper);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  .arch-canvas.dragging { cursor: grabbing; }
+  .arch-canvas svg { display: block; }
+
+  .arch-info {
+    flex: 0 0 240px;
+    min-width: 220px;
+    border: 1px solid var(--line);
+    background: var(--paper-raised);
+    padding: 0.9rem 1rem;
+    font-size: 0.82rem;
+    max-height: 640px;
+    overflow-y: auto;
+  }
+  .arch-info-hint { margin: 0 0 0.8rem; color: var(--ink-soft); font-size: 0.82rem; }
+  .arch-stat-row {
+    display: flex; justify-content: space-between; gap: 0.6rem;
+    padding: 0.28rem 0; border-bottom: 1px solid var(--line);
+    color: var(--ink-soft); font-size: 0.78rem;
+  }
+  .arch-stat-row:last-child { border-bottom: none; }
+  .arch-stat-n { color: var(--ink); font-weight: 600; font-family: var(--mono-font); }
+
+  .arch-info-title {
+    font-family: var(--mono-font);
+    font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
+  }
+  .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+  .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
+  .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
+  .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
+
+  .arch-node { cursor: pointer; }
+  .arch-node rect { transition: opacity 0.15s ease; }
+  .arch-node text { pointer-events: none; }
+  .arch-edge { transition: opacity 0.15s ease; }
+  .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
+  .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
+  #arch-arrow path { fill: var(--blueprint); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .arch-node rect, .arch-edge { transition: none; }
+  }
+
+  @media (max-width: 720px) {
+    .arch-canvas { height: 420px; }
+    .arch-info { flex-basis: 100%; }
+  }
+</style>
+
+<div class="arch-diagram">
+  <div class="arch-legend">
+    <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> профилировано в этом руководстве</span>
+    <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> упомянуто, но ещё не профилировано</span>
+  </div>
+  <div class="arch-wrap">
+    <div class="arch-canvas" id="arch-canvas">
+      <svg id="arch-svg" width="100%" height="100%"></svg>
+    </div>
+    <div class="arch-info" id="arch-info">
+      <div id="arch-info-body">
+        <p class="arch-info-hint">Наведите курсор или перейдите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи.</p>
+        <div class="arch-stat-row"><span>Показано компонентов</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
+        <div class="arch-stat-row"><span>Ресурсов</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
+        <div class="arch-stat-row"><span>Связей</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="architecture-diagram.js"></script>

--- a/input/translations/uz/pagecontent/components.md
+++ b/input/translations/uz/pagecontent/components.md
@@ -1,3 +1,5 @@
+Ushbu komponentlar bir-biri bilan qanday bog'langanini sahifa oxiridagi [komponentlararo resurs arxitekturasi](#komponentlararo-resurs-arxitekturasi) diagrammasida ko'rishingiz mumkin.
+
 ### Tez tibbiy yordam
 \< bu xizmat bo'yicha qisqacha tavsif keyinchalik qo'shiladi \\>
 
@@ -172,3 +174,117 @@ Komponent quyidagilarni ta'minlaydi:
 - vaksinatsiyaning to'liq hayotiy siklini qo'llab-quvvatlashni, jumladan tayinlash, rejalashtirish, o'tkazish va kuzatishni;
 - tibbiy axborot tizimlari va milliy vaksinatsiya dasturlari bilan integratsiyani;
 - aholining immunizatsiya darajasini monitoring qilish uchun analitika va hisobotlarni shakllantirishni.
+
+### Komponentlararo resurs arxitekturasi
+
+Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan almashadi. Ushbu diagramma resurs darajasiga tushadi: har bir komponent qaysi resurslarga egalik qiladi va ulardan qaysilari boshqa komponent bilan bog'lanadi. Oddiy chiziqlar ikki komponentning keng integratsiyasini, strelkalar esa muayyan resursning bir komponentdan boshqasiga o'tishini ko'rsatadi. Ko'chirish uchun sudrang, masshtabni o'zgartirish uchun aylantiring, aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting.
+
+<br clear="all"/>
+
+<style>
+  .arch-diagram {
+    --blueprint: #2255AA;
+    --blueprint-soft: #dce7f6;
+    --pencil-soft: #e6e6e6;
+    --ink: #1b232a;
+    --ink-soft: #5c6b74;
+    --paper: #ffffff;
+    --paper-raised: #f4f7f9;
+    --line: #c9d2d6;
+    --grid: rgba(27, 35, 42, 0.05);
+    --mono-font: ui-monospace, "SFMono-Regular", Menlo, Consolas, "Liberation Mono", monospace;
+    margin: 1.5rem 0;
+  }
+  .arch-legend { display: flex; flex-wrap: wrap; gap: 1.1rem; margin: 0 0 0.7rem; font-size: 0.78rem; color: var(--ink-soft); }
+  .arch-legend span { display: inline-flex; align-items: center; gap: 0.35rem; }
+  .arch-legend span[data-legend] { cursor: pointer; padding: 2px 4px; margin: -2px -4px; border-radius: 3px; }
+  .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
+  .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
+  .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+
+  .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
+
+  .arch-canvas {
+    flex: 1 1 480px;
+    height: 640px;
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    cursor: grab;
+    touch-action: none;
+    background-color: var(--paper);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+    background-size: 24px 24px;
+  }
+  .arch-canvas.dragging { cursor: grabbing; }
+  .arch-canvas svg { display: block; }
+
+  .arch-info {
+    flex: 0 0 240px;
+    min-width: 220px;
+    border: 1px solid var(--line);
+    background: var(--paper-raised);
+    padding: 0.9rem 1rem;
+    font-size: 0.82rem;
+    max-height: 640px;
+    overflow-y: auto;
+  }
+  .arch-info-hint { margin: 0 0 0.8rem; color: var(--ink-soft); font-size: 0.82rem; }
+  .arch-stat-row {
+    display: flex; justify-content: space-between; gap: 0.6rem;
+    padding: 0.28rem 0; border-bottom: 1px solid var(--line);
+    color: var(--ink-soft); font-size: 0.78rem;
+  }
+  .arch-stat-row:last-child { border-bottom: none; }
+  .arch-stat-n { color: var(--ink); font-weight: 600; font-family: var(--mono-font); }
+
+  .arch-info-title {
+    font-family: var(--mono-font);
+    font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
+  }
+  .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+  .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
+  .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
+  .arch-rel-desc { font-size: 0.76rem; color: var(--ink-soft); margin: 0.15rem 0 0; }
+
+  .arch-node { cursor: pointer; }
+  .arch-node rect { transition: opacity 0.15s ease; }
+  .arch-node text { pointer-events: none; }
+  .arch-edge { transition: opacity 0.15s ease; }
+  .arch-node.dim, .arch-edge.dim { opacity: 0.15; }
+  .arch-node.active { filter: drop-shadow(0 0 3px var(--blueprint)); }
+  #arch-arrow path { fill: var(--blueprint); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .arch-node rect, .arch-edge { transition: none; }
+  }
+
+  @media (max-width: 720px) {
+    .arch-canvas { height: 420px; }
+    .arch-info { flex-basis: 100%; }
+  }
+</style>
+
+<div class="arch-diagram">
+  <div class="arch-legend">
+    <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> ushbu qo'llanmada profillangan</span>
+    <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> nomlangan, lekin hali profillanmagan</span>
+  </div>
+  <div class="arch-wrap">
+    <div class="arch-canvas" id="arch-canvas">
+      <svg id="arch-svg" width="100%" height="100%"></svg>
+    </div>
+    <div class="arch-info" id="arch-info">
+      <div id="arch-info-body">
+        <p class="arch-info-hint">Aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting.</p>
+        <div class="arch-stat-row"><span>Ko'rsatilgan komponentlar</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
+        <div class="arch-stat-row"><span>Resurslar</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
+        <div class="arch-stat-row"><span>Aloqalar</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="architecture-diagram.js"></script>


### PR DESCRIPTION
Adds an interactive diagram to the bottom of the Components page showing which FHIR resources each component owns and how they connect, built as a vendored SVG/JS widget (no external dependencies) with hover-to-inspect and a resource-profiling legend.