### PR TITLE
Star the resources each component is responsible for in the architecture diagram

### DIFF
--- a/input/images/architecture-diagram.js
+++ b/input/images/architecture-diagram.js
@@ -37,34 +37,34 @@
   ];
 
   var COMPONENTS = {
-    MDM: { short: "MDM", label: "Master Data Management (MDM)", resources: [
+    MDM: { service: "mdm", short: "MDM", label: "Master Data Management (MDM)", resources: [
       { name: "Patient", profiled: true }, { name: "Organization", profiled: true },
       { name: "Practitioner", profiled: true }, { name: "PractitionerRole", profiled: true },
       { name: "HealthcareService", profiled: true }, { name: "Location", profiled: true }
     ]},
-    MSM: { short: "MSM", label: "Metadata and Security Management (MSM)", resources: [
+    MSM: { service: "metadata", short: "MSM", label: "Metadata and Security Management (MSM)", resources: [
       { name: "StructureDefinition", profiled: true }, { name: "ValueSet", profiled: true },
       { name: "CodeSystem", profiled: true }, { name: "CapabilityStatement", profiled: true },
       { name: "Provenance", profiled: true }, { name: "AuditEvent", profiled: true }, { name: "Consent", profiled: true }
     ]},
-    CHR: { short: "CHR", label: "Clinical Health Records (CHR)", resources: [
+    CHR: { service: "chr", short: "CHR", label: "Clinical Health Records (CHR)", resources: [
       { name: "Patient", profiled: true }, { name: "EpisodeOfCare", profiled: true }, { name: "Condition", profiled: true },
       { name: "Observation", profiled: true }, { name: "Procedure", profiled: true }, { name: "AllergyIntolerance", profiled: true },
       { name: "MedicationRequest" }
     ]},
-    PHJM: { short: "PHJM", label: "Patient health journey management (PHJM)", resources: [
+    PHJM: { service: "phjm", short: "PHJM", label: "Patient health journey management (PHJM)", resources: [
       { name: "EpisodeOfCare", profiled: true }, { name: "Encounter", profiled: true }, { name: "Condition", profiled: true },
       { name: "Observation", profiled: true }, { name: "CarePlan" }, { name: "Questionnaire", profiled: true },
       { name: "QuestionnaireResponse", profiled: true }
     ]},
-    LAB: { short: "Laboratory", label: "Laboratory", resources: [
+    LAB: { service: "laboratory", short: "Laboratory", label: "Laboratory", resources: [
       { name: "Observation", profiled: true }, { name: "Specimen", profiled: true },
       { name: "DiagnosticReport", profiled: true }, { name: "ServiceRequest", profiled: true }
     ]},
-    REFERRALS: { short: "Referrals", label: "Referrals", resources: [
+    REFERRALS: { service: "referrals", short: "Referrals", label: "Referrals", resources: [
       { name: "ServiceRequest", profiled: true }, { name: "Task", profiled: true }
     ]},
-    REIMB: { short: "Reimbursement", label: "Reimbursement", resources: [
+    REIMB: { service: "reimbursement", short: "Reimbursement", label: "Reimbursement", resources: [
       { name: "Claim", profiled: true }, { name: "ClaimResponse", profiled: true }, { name: "Encounter", profiled: true },
       { name: "Procedure", profiled: true }, { name: "MedicationDispense", profiled: true }, { name: "Condition", profiled: true },
       { name: "Observation", profiled: true }, { name: "CarePlan" }, { name: "Composition", profiled: true }
@@ -72,26 +72,57 @@
     SCREEN: { short: "Screening Schedules", label: "Screening Schedules Management", resources: [
       { name: "Questionnaire", profiled: true }
     ]},
-    VACC: { short: "Vaccination Mgmt", label: "Vaccination Management", resources: [
+    VACC: { service: "vm", short: "Vaccination Mgmt", label: "Vaccination Management", resources: [
       { name: "Immunization", profiled: true }, { name: "ImmunizationRecommendation", profiled: true },
       { name: "PlanDefinition", profiled: true }, { name: "ActivityDefinition", profiled: true },
       { name: "AdverseEvent", profiled: true }, { name: "Encounter", profiled: true },
       { name: "Observation", profiled: true }
     ]},
-    BLOOD: { short: "Blood Mgmt", label: "Blood Management", resources: [
+    BLOOD: { service: "blood", short: "Blood Mgmt", label: "Blood Management", resources: [
       { name: "ServiceRequest", profiled: true }, { name: "SupplyRequest" },
       { name: "Procedure", profiled: true }, { name: "Observation", profiled: true },
       { name: "InventoryItem" }, { name: "InventoryReport" },
       { name: "PlanDefinition", profiled: true }, { name: "Group", profiled: true },
       { name: "BiologicallyDerivedProduct" }, { name: "DiagnosticReport", profiled: true }
     ]},
-    NURSING: { short: "Nursing", label: "Nursing", resources: [
+    NURSING: { service: "nursing", short: "Nursing", label: "Nursing", resources: [
       { name: "ServiceRequest", profiled: true }, { name: "Encounter", profiled: true },
       { name: "Observation", profiled: true }, { name: "Procedure", profiled: true },
       { name: "Condition", profiled: true }, { name: "Questionnaire", profiled: true },
       { name: "QuestionnaireResponse", profiled: true }
     ]}
   };
+
+  // Which platform service is responsible for each FHIR resource type, from
+  // the platform team's service-to-resource allocation. A resource type used
+  // by several components is still stored by exactly one service, so this is
+  // keyed by resource type rather than by component. Resource types with no
+  // service listed yet (CapabilityStatement, Provenance, AuditEvent, Consent,
+  // InventoryReport, Group) simply have no entry.
+  var SERVICES = {
+    metadata: ["NamingSystem", "ValueSet", "CodeSystem", "ConceptMap", "StructureDefinition", "OperationDefinition", "SearchParameter"],
+    mdm: ["Organization", "Practitioner", "PractitionerRole", "Location", "Person", "HealthcareService"],
+    referrals: ["Task"],
+    prescription: ["Medication", "MedicationAdministration"],
+    aas: ["Appointment", "Schedule", "Slot"],
+    laboratory: ["Specimen", "DiagnosticReport", "ObservationDefinition", "ServiceRequest"],
+    dai: ["ImagingStudy"],
+    ambulance: ["Communication"],
+    supplies: ["SupplyRequest", "SupplyDelivery", "InventoryItem"],
+    reimbursement: ["Claim", "ClaimResponse", "Coverage", "Invoice", "PaymentNotice", "PaymentReconciliation"],
+    cds: ["Library", "GuidanceResponse"],
+    nursing: ["CarePlan"],
+    blood: ["BiologicallyDerivedProduct"],
+    vm: ["Immunization", "PlanDefinition", "ActivityDefinition", "ImmunizationRecommendation", "AdverseEvent"],
+    phr: ["Measure", "RiskAssessment"],
+    phjm: ["Patient", "RelatedPerson", "Condition", "EpisodeOfCare", "Encounter", "Questionnaire", "QuestionnaireResponse", "Observation"],
+    chr: ["AllergyIntolerance", "Flag", "Procedure", "Composition", "MedicationRequest", "MedicationDispense", "Goal"],
+    coordinator: ["Bundle"]
+  };
+  var SERVICE_OF = {};
+  Object.keys(SERVICES).forEach(function (s) {
+    SERVICES[s].forEach(function (r) { SERVICE_OF[r] = s; });
+  });
 
   var EDGES = [
     { from: "CHR", to: "MDM", kind: "fullCompat" },
@@ -148,6 +179,10 @@
       noRelations: "No stated or inferred relationships for this node.",
       profiledTitle: "Defined in this IG",
       unprofiledTitle: "Named, not yet defined",
+      ownTitle: "Resources the component is responsible for",
+      own: "the component is responsible for this resource",
+      service: "Service",
+      noService: "No service assigned yet",
       resourceCount: function (n) { return n + (n === 1 ? " resource" : " resources"); }
     },
     ru: {
@@ -175,6 +210,10 @@
       noRelations: "Для этого узла нет заявленных или предполагаемых связей.",
       profiledTitle: "Определено в этом руководстве",
       unprofiledTitle: "Упомянуто, но ещё не определено",
+      ownTitle: "Ресурсы, за которые отвечает компонент",
+      own: "компонент отвечает за этот ресурс",
+      service: "Сервис",
+      noService: "Сервис ещё не назначен",
       // 1 ресурс / 2-4 ресурса / 5+ ресурсов, with the 11-14 exception.
       resourceCount: function (n) {
         var m10 = n % 10, m100 = n % 100;
@@ -208,9 +247,19 @@
       noRelations: "Bu tugun uchun belgilangan yoki taxmin qilingan aloqalar yo'q.",
       profiledTitle: "Ushbu qo'llanmada belgilangan",
       unprofiledTitle: "Nomlangan, lekin hali belgilanmagan",
+      ownTitle: "Komponent javobgar bo'lgan resurslar",
+      own: "komponent ushbu resurs uchun javobgar",
+      service: "Xizmat",
+      noService: "Xizmat hali belgilanmagan",
       resourceCount: function (n) { return n + " ta resurs"; }
     }
   };
+
+  // True when the component's own service is the one storing the resource.
+  function isOwn(compId, name) {
+    var svc = COMPONENTS[compId].service;
+    return !!svc && SERVICE_OF[name] === svc;
+  }
 
   var LANG = (document.documentElement.getAttribute("lang") || "en").slice(0, 2).toLowerCase();
   var T = STRINGS[LANG] || STRINGS.en;
@@ -290,7 +339,8 @@
               x: curX + PILL_INSET,
               y: curY + TITLE_H + PAD_TOP + ri * (PILL_H + PILL_GAP),
               w: BOX_W - 2 * PILL_INSET, h: PILL_H,
-              name: r.name, profiled: !!r.profiled, compId: id
+              name: r.name, profiled: !!r.profiled, compId: id,
+              service: SERVICE_OF[r.name] || null, own: isOwn(id, r.name)
             };
           });
         }
@@ -389,7 +439,7 @@
       g.appendChild(r);
 
       var text = el('text', {
-        x: isBox ? rect.x + 10 : rect.x + rect.w / 2,
+        x: isBox ? rect.x + 10 : rect.x + rect.w / 2 + (data.own ? 6 : 0),
         y: isBox ? rect.y + 19 : rect.y + rect.h / 2 + 4,
         'text-anchor': isBox ? 'start' : 'middle',
         'font-family': MONO_FONT,
@@ -399,6 +449,14 @@
       text.style.fill = isBox ? 'var(--ink)' : (data.profiled ? 'var(--blueprint)' : 'var(--ink-soft)');
       text.textContent = isBox ? compShort(id) : data.name;
       g.appendChild(text);
+      if (!isBox && data.own) {
+        var mark = el('text', {
+          x: rect.x + 6, y: rect.y + rect.h / 2 + 4, 'font-family': MONO_FONT, 'font-size': '10'
+        });
+        mark.style.fill = 'var(--blueprint)';
+        mark.textContent = '★';
+        g.appendChild(mark);
+      }
 
       if (isBox && !expanded[id]) {
         var count = el('text', { x: rect.x + 10, y: rect.y + 40, 'font-family': MONO_FONT, 'font-size': '10' });
@@ -416,7 +474,8 @@
         g.appendChild(toggle);
       }
 
-      var label = isBox ? compLabel(id) : (data.name + ' — ' + compLabel(data.compId));
+      var label = isBox ? compLabel(id) : (data.name + ' — ' + compLabel(data.compId)
+        + ' — ' + T.service + ': ' + (data.service || T.noService) + (data.own ? ' (' + T.own + ')' : ''));
       g.setAttribute('aria-label', label);
       if (openable) g.setAttribute('aria-expanded', expanded[id] ? 'true' : 'false');
       nodeLayer.appendChild(g);
@@ -424,7 +483,7 @@
       // A few resource type names, and some component names once translated,
       // are wider than the box holding them. Rather than size every box to the
       // longest string, condense just the labels that do not fit.
-      var avail = isBox ? rect.w - 10 - (openable ? 20 : 10) : rect.w - 6;
+      var avail = isBox ? rect.w - 10 - (openable ? 20 : 10) : rect.w - 6 - (data.own ? 18 : 0);
       if (text.getComputedTextLength() > avail) {
         text.setAttribute('textLength', avail);
         text.setAttribute('lengthAdjust', 'spacingAndGlyphs');
@@ -483,6 +542,11 @@
       var s = document.createElement('p'); s.className = 'arch-info-sub';
       s.textContent = isBox ? compLabel(id) : compLabel(pills[id].compId);
       wrap.appendChild(t); wrap.appendChild(s);
+      if (!isBox) {
+        var svc = document.createElement('p'); svc.className = 'arch-info-service';
+        svc.textContent = T.service + ': ' + (pills[id].service || T.noService) + (pills[id].own ? ' · ' + T.own : '');
+        wrap.appendChild(svc);
+      }
 
       if (related.length === 0) {
         var hint = document.createElement('p');
@@ -515,24 +579,28 @@
     function setLegendActive(legendKind) {
       clearHighlight();
       drawn.forEach(function (rec) { rec.el.classList.add('dim'); });
+      function matches(kind, r, cid) {
+        if (kind === 'own') return isOwn(cid, r.name);
+        return kind === 'profiled' ? !!r.profiled : !r.profiled;
+      }
       var matchCount = 0;
       Object.keys(COMPONENTS).forEach(function (cid) {
         COMPONENTS[cid].resources.forEach(function (r) {
-          if (legendKind === 'profiled' ? !!r.profiled : !r.profiled) matchCount++;
+          if (matches(legendKind, r, cid)) matchCount++;
         });
       });
       Object.keys(nodeEls).forEach(function (nid) {
         // With every component closed there is nothing to pick out, so the
         // boxes stay as they are rather than all dimming at once.
         if (boxes[nid]) { if (anyPills) nodeEls[nid].el.classList.add('dim'); return; }
-        var match = legendKind === 'profiled' ? pills[nid].profiled : !pills[nid].profiled;
+        var match = matches(legendKind, pills[nid], pills[nid].compId);
         nodeEls[nid].el.classList.toggle('dim', !match);
         nodeEls[nid].el.classList.toggle('active', match);
       });
 
       var wrap = document.createElement('div');
       var t = document.createElement('p'); t.className = 'arch-info-title';
-      t.textContent = legendKind === 'profiled' ? T.profiledTitle : T.unprofiledTitle;
+      t.textContent = legendKind === 'own' ? T.ownTitle : (legendKind === 'profiled' ? T.profiledTitle : T.unprofiledTitle);
       var s = document.createElement('p'); s.className = 'arch-info-sub';
       s.textContent = T.resourceCount(matchCount);
       wrap.appendChild(t); wrap.appendChild(s);

--- a/input/pagecontent/components.md
+++ b/input/pagecontent/components.md
@@ -224,7 +224,7 @@ The [Immunization](workflow-immunization.html) workflow shows how the national s
 
 ### Cross-component resource architecture
 
-In practice, several of the components described above exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly, or several resource connections merged into one while both components are closed; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections.
+In practice, several of the components described above exchange the same underlying FHIR resources. This diagram drops to the resource level: which resources each component owns, and which of those resources connect to another component. Plain lines show two components integrating broadly, or several resource connections merged into one while both components are closed; arrows show a specific resource flowing from one component into another. Drag to pan, scroll to zoom, and hover or tab to a resource, component, or legend item to see its connections. A ★ marks a resource the component itself is responsible for; the others it shares with the component that is.
 
 <br clear="all"/>
 
@@ -248,6 +248,7 @@ In practice, several of the components described above exchange the same underly
   .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
   .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
   .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+  .arch-legend .swatch-star { color: var(--blueprint); font-size: 0.85rem; line-height: 1; }
 
   .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
 
@@ -292,6 +293,7 @@ In practice, several of the components described above exchange the same underly
     font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
   }
   .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-info-service { font-family: var(--mono-font); font-size: 0.76rem; color: var(--ink-soft); margin: -0.55rem 0 0.8rem; }
   .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
   .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
   .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
@@ -319,6 +321,7 @@ In practice, several of the components described above exchange the same underly
   <div class="arch-legend">
     <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> defined in this IG</span>
     <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> named, not yet defined</span>
+    <span data-legend="own" tabindex="0" role="button"><span class="swatch-star">★</span> the component is responsible for this resource</span>
   </div>
   <div class="arch-wrap">
     <div class="arch-canvas" id="arch-canvas">
@@ -326,7 +329,7 @@ In practice, several of the components described above exchange the same underly
     </div>
     <div class="arch-info" id="arch-info">
       <div id="arch-info-body">
-        <p class="arch-info-hint">Click a component to open its resources. Hover or tab to a resource, component, or legend item to see what it connects to.</p>
+        <p class="arch-info-hint">Click a component to open its resources; ★ marks the ones the component is responsible for. Hover or tab to a resource, component, or legend item to see what it connects to.</p>
         <div class="arch-stat-row"><span>Components shown</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
         <div class="arch-stat-row"><span>Resources</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
         <div class="arch-stat-row"><span>Relationships</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>

--- a/input/translations/ru/pagecontent/components.md
+++ b/input/translations/ru/pagecontent/components.md
@@ -257,7 +257,7 @@ CHR обеспечивает стандартизированное ведени
 
 ### Межкомпонентная архитектура ресурсов
 
-На практике несколько описанных выше компонентов обмениваются одними и теми же FHIR-ресурсами. Эта диаграмма спускается на уровень ресурсов: какими ресурсами владеет каждый компонент и какие из них связывают его с другим компонентом. Сплошные линии показывают широкую интеграцию двух компонентов либо несколько ресурсных связей, объединённых в одну, пока оба компонента свёрнуты; стрелки - передачу конкретного ресурса из одного компонента в другой. Перетаскивайте для перемещения, прокручивайте для масштабирования, наводите курсор или переходите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи.
+На практике несколько описанных выше компонентов обмениваются одними и теми же FHIR-ресурсами. Эта диаграмма спускается на уровень ресурсов: какими ресурсами владеет каждый компонент и какие из них связывают его с другим компонентом. Сплошные линии показывают широкую интеграцию двух компонентов либо несколько ресурсных связей, объединённых в одну, пока оба компонента свёрнуты; стрелки - передачу конкретного ресурса из одного компонента в другой. Перетаскивайте для перемещения, прокручивайте для масштабирования, наводите курсор или переходите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи. ★ отмечает ресурс, за который отвечает сам компонент; остальные он использует совместно с компонентом, который за них отвечает.
 
 <br clear="all"/>
 
@@ -281,6 +281,7 @@ CHR обеспечивает стандартизированное ведени
   .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
   .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
   .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+  .arch-legend .swatch-star { color: var(--blueprint); font-size: 0.85rem; line-height: 1; }
 
   .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
 
@@ -325,6 +326,7 @@ CHR обеспечивает стандартизированное ведени
     font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
   }
   .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-info-service { font-family: var(--mono-font); font-size: 0.76rem; color: var(--ink-soft); margin: -0.55rem 0 0.8rem; }
   .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
   .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
   .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
@@ -352,6 +354,7 @@ CHR обеспечивает стандартизированное ведени
   <div class="arch-legend">
     <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> определено в этом руководстве</span>
     <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> упомянуто, но ещё не определено</span>
+    <span data-legend="own" tabindex="0" role="button"><span class="swatch-star">★</span> компонент отвечает за этот ресурс</span>
   </div>
   <div class="arch-wrap">
     <div class="arch-canvas" id="arch-canvas">
@@ -359,7 +362,7 @@ CHR обеспечивает стандартизированное ведени
     </div>
     <div class="arch-info" id="arch-info">
       <div id="arch-info-body">
-        <p class="arch-info-hint">Нажмите на компонент, чтобы раскрыть его ресурсы. Наведите курсор или перейдите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи.</p>
+        <p class="arch-info-hint">Нажмите на компонент, чтобы раскрыть его ресурсы; ★ отмечает ресурсы, за которые отвечает компонент. Наведите курсор или перейдите табуляцией к ресурсу, компоненту или элементу легенды, чтобы увидеть его связи.</p>
         <div class="arch-stat-row"><span>Показано компонентов</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
         <div class="arch-stat-row"><span>Ресурсов</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
         <div class="arch-stat-row"><span>Связей</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>

--- a/input/translations/uz/pagecontent/components.md
+++ b/input/translations/uz/pagecontent/components.md
@@ -253,7 +253,7 @@ Komponent quyidagilarni ta'minlaydi:
 
 ### Komponentlararo resurs arxitekturasi
 
-Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan almashadi. Ushbu diagramma resurs darajasiga tushadi: har bir komponent qaysi resurslarga egalik qiladi va ulardan qaysilari boshqa komponent bilan bog'lanadi. Oddiy chiziqlar ikki komponentning keng integratsiyasini yoki ikkala komponent yopiq bo'lganda bitta chiziqqa birlashtirilgan bir nechta resurs aloqasini, strelkalar esa muayyan resursning bir komponentdan boshqasiga o'tishini ko'rsatadi. Ko'chirish uchun sudrang, masshtabni o'zgartirish uchun aylantiring, aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting.
+Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan almashadi. Ushbu diagramma resurs darajasiga tushadi: har bir komponent qaysi resurslarga egalik qiladi va ulardan qaysilari boshqa komponent bilan bog'lanadi. Oddiy chiziqlar ikki komponentning keng integratsiyasini yoki ikkala komponent yopiq bo'lganda bitta chiziqqa birlashtirilgan bir nechta resurs aloqasini, strelkalar esa muayyan resursning bir komponentdan boshqasiga o'tishini ko'rsatadi. Ko'chirish uchun sudrang, masshtabni o'zgartirish uchun aylantiring, aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting. ★ komponentning o'zi javobgar bo'lgan resursni belgilaydi; qolganlarini u ular uchun javobgar komponent bilan birgalikda ishlatadi.
 
 <br clear="all"/>
 
@@ -277,6 +277,7 @@ Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan 
   .arch-legend span[data-legend]:hover, .arch-legend span[data-legend]:focus-visible { background: var(--paper-raised); }
   .arch-legend .swatch-box { width: 12px; height: 12px; background: var(--blueprint-soft); border: 1px solid var(--line); }
   .arch-legend .swatch-box.pale { background: var(--pencil-soft); }
+  .arch-legend .swatch-star { color: var(--blueprint); font-size: 0.85rem; line-height: 1; }
 
   .arch-wrap { display: flex; gap: 1rem; align-items: flex-start; flex-wrap: wrap; }
 
@@ -321,6 +322,7 @@ Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan 
     font-weight: 600; font-size: 0.92rem; color: var(--ink); margin: 0 0 0.2rem;
   }
   .arch-info-sub { font-size: 0.76rem; color: var(--ink-soft); margin: 0 0 0.8rem; }
+  .arch-info-service { font-family: var(--mono-font); font-size: 0.76rem; color: var(--ink-soft); margin: -0.55rem 0 0.8rem; }
   .arch-rel-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
   .arch-rel-item { border-left: 2px solid var(--blueprint); padding-left: 0.6rem; }
   .arch-rel-head { font-size: 0.8rem; color: var(--ink); font-weight: 600; }
@@ -348,6 +350,7 @@ Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan 
   <div class="arch-legend">
     <span data-legend="profiled" tabindex="0" role="button"><span class="swatch-box"></span> ushbu qo'llanmada belgilangan</span>
     <span data-legend="unprofiled" tabindex="0" role="button"><span class="swatch-box pale"></span> nomlangan, lekin hali belgilanmagan</span>
+    <span data-legend="own" tabindex="0" role="button"><span class="swatch-star">★</span> komponent ushbu resurs uchun javobgar</span>
   </div>
   <div class="arch-wrap">
     <div class="arch-canvas" id="arch-canvas">
@@ -355,7 +358,7 @@ Amalda yuqorida tavsiflangan bir nechta komponent bir xil FHIR resurslari bilan 
     </div>
     <div class="arch-info" id="arch-info">
       <div id="arch-info-body">
-        <p class="arch-info-hint">Komponent resurslarini ochish uchun uni bosing. Aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting.</p>
+        <p class="arch-info-hint">Komponent resurslarini ochish uchun uni bosing; ★ komponent javobgar bo'lgan resurslarni belgilaydi. Aloqalarni ko'rish uchun resurs, komponent yoki legenda elementiga sichqonchani olib boring yoki tab bilan o'ting.</p>
         <div class="arch-stat-row"><span>Ko'rsatilgan komponentlar</span><span class="arch-stat-n" id="arch-stat-components">–</span></div>
         <div class="arch-stat-row"><span>Resurslar</span><span class="arch-stat-n" id="arch-stat-resources">–</span></div>
         <div class="arch-stat-row"><span>Aloqalar</span><span class="arch-stat-n" id="arch-stat-relationships">–</span></div>


### PR DESCRIPTION
Adds a ★ to each resource on a component card when the component's own platform service is responsible for it (per the service-to-resource allocation), with a legend item, side-panel service line and ru/uz strings.